### PR TITLE
Do NOT trim or normalise away any whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,10 @@ module.exports = function( ss_key, auth_id ){
 
 			if ( body ){
 				var parser = new xml2js.Parser(xml2js.defaults["0.1"]);
+				//Override a couple of 0.1 options to 0.2 values
+				parser.options['trim'] = false;
+				parser.options['normalize'] = false;
+
 				parser.on("end", function(result) {
 					cb( null, result, body );
 				});


### PR DESCRIPTION
Because we use the 0.1 defaults, a couple of annoying options
concerning whitespace are used. Change overrides these. Further
background: https://npmjs.org/package/xml2js and
https://github.com/Leonidas-from-XIV/node-xml2js/issues/55
