### PR TITLE
Updated google client login dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "request": "~2.29.0",
     "xml2js": "~0.4.0",
-    "googleclientlogin": "0.2.x"
+    "googleclientlogin": ">=0.2.8"
   },
   "devDependencies": {
     "nodeunit": "~0.8.2",


### PR DESCRIPTION
0.2.8 fixes a crash when google can't be reached (see https://github.com/Ajnasz/GoogleClientLogin/commit/225a132f3864989517f48ff091026f72137b7ffd)
