### PR TITLE
Revert "Check if worksheet_id is a number and greater than 0"

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,10 +92,7 @@ module.exports = function( ss_key, auth_id ){
     });
   }
   this.addRow = function( worksheet_id, data, cb ){
-    worksheet_id = parseInt(worksheet_id);
-    if (typeof worksheet_id !== 'number' || worksheet_id < 0) {
-      throw new Error('Valid worksheet not specified.');
-    }
+    if( !worksheet_id ) throw new Error("Worksheet not specified.");
 
     var data_xml = '<entry xmlns="http://www.w3.org/2005/Atom" xmlns:gsx="http://schemas.google.com/spreadsheets/2006/extended">' + "\n";
       Object.keys(data).forEach(function(key) {


### PR DESCRIPTION
Looks like Google either changed their API or my assumption was wrong.

Apparently the first worksheet is always `od6` now, so this needs to be reverted. Apologies for the trouble

(This reverts commit 2b53c69fa7738de3f5f1caa1662b3172df5514b4)