### PR TITLE
Adding numericValue property to cell

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,6 +270,7 @@ var SpreadsheetCell = function( spreadsheet, worksheet_id, data ){
   self.row = parseInt(data['gs:cell']['$']['row']);
   self.col = parseInt(data['gs:cell']['$']['col']);
   self.value = data['gs:cell']['_'];
+  self.numericValue = data['gs:cell']['$']['numericValue'];
 
   self['_links'] = [];
   links = forceArray( data.link );


### PR DESCRIPTION
I don't know if there's a better way to achieve this, but if the spreadsheet is using a different locale than US, it's useful to have the numericValue so a parseFloat can return the exact value, instead of trying to parse the formatted value string.