### PR TITLE
The first row is always skipped

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ module.exports = function( ss_key, auth_id, options ){
       var entries_xml = xml.match(/<entry[^>]*>([\s\S]*?)<\/entry>/g);
       var rows = [];
       var entries = forceArray( data.entry );
-      var i=0;
+      var i=-1;
       entries.forEach( function( row_data ) {
         rows.push( new SpreadsheetRow( self, row_data, entries_xml[ i++ ] ) );
       });


### PR DESCRIPTION
Due to the i++ on 180, when starting at 0 it gets the entries_xml[1] the first time around. This means that the first row entries_xml[0] is always skipped and not returned :)