### PR TITLE
Add Gdata-version header

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,9 @@ module.exports = function( ss_key, auth_id, options ){
       }
     }
 
+    // This is a required http header for 3.0 version of the API.
+    headers['Gdata-version'] = '3.0';
+
     if ( method == 'POST' || method == 'PUT' ){
       headers['content-type'] = 'application/atom+xml';
     }


### PR DESCRIPTION
The problem:
I used service token based authorization to test google-spreadsheet, which I obtained through npm. The test returned an empty response even for the getRows() call. 

The fix:
I used the Oauth 2.0 playground (https://developers.google.com/oauthplayground/) to understand how the APIs work. The requests in the Oauth 2.0 playground contained a Gdata-version header whose value was set to 3.0. When I added this header to google-spreadsheet in the makeFeedRequest function, the getRows() worked correctly. This change also fixed other functions like addRow().