### PR TITLE
Add `If-Match` header to POST and PUT requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ var GooogleSpreadsheet = function( ss_key, auth_id, options ){
 
         if ( method == 'POST' || method == 'PUT' ){
           headers['content-type'] = 'application/atom+xml';
+          headers['If-Match'] = '*';
         }
 
         if ( method == 'GET' && query_or_data ) {


### PR DESCRIPTION
Google kept kicking back the following error when this header wasn't present.

> HTTP error 403: Forbidden "If-Match or If-None-Match header or entry etag attribute required"

I'll admit to not having my mind fully around the problem yet, but if this makes sense to you, it at least fixed it for me. :)