### PR TITLE
Fix Error 403 on bulkUpdateCells

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ var GooogleSpreadsheet = function( ss_key, auth_id, options ){
           headers['content-type'] = 'application/atom+xml';
         }
 
-        if (method == 'PUT') {
+        if (method == 'PUT' || method == 'POST' && query_or_data.includes('http://schemas.google.com/gdata/batch') ) {
           headers['If-Match'] = '*';
         }
 


### PR DESCRIPTION
When bulk updating empty cells, the google api was returning
```xml
<?xml version='1.0' encoding='UTF-8'?>
<feed xmlns="http://www.w3.org/2005/Atom" xmlns:batch="http://schemas.google.com/gdata/batch" xmlns:gs="http://schemas.google.com/spreadsheets/2006" xmlns:openSearch="http://a9.com/-/spec/opensearch/1.1/">
    <id>https://spreadsheets.google.com/feeds/cells/.../41/batch/1457080106124</id>
    <updated>2016-03-04T08:28:26.131Z</updated>
    <category scheme="http://schemas.google.com/spreadsheets/2006" term="http://schemas.google.com/spreadsheets/2006#cell"/>
    <title>Batch Feed</title>
    <entry>
        <id>https://spreadsheets.google.com/feeds/cells/.../41/R1C1</id>
        <updated>2016-03-04T08:28:26.132Z</updated>
        <title>Error</title>
        <content>If-Match or If-None-Match header or entry etag attribute required</content>
        <batch:id>https://spreadsheets.google.com/feeds/cells/.../41/R1C1</batch:id>
        <batch:status code="403" reason="If-Match or If-None-Match header or entry etag attribute required"/>
        <batch:operation type="update"/>
    </entry>
    ...
</feed>
```

After changing the code it started working properly.

After looking through the pull requests, this would also be solved by https://github.com/theoephraim/node-google-spreadsheet/pull/76.