### PR TITLE
Fix DELETE worksheet url

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ var GooogleSpreadsheet = function( ss_key, auth_id, options ){
 
   this.removeWorksheet = function ( worksheet_id, cb ){
     if (!this.isAuthActive()) return cb(new Error(REQUIRE_AUTH_MESSAGE));
-    self.makeFeedRequest( ["worksheets", ss_key, worksheet_id], 'DELETE', cb );
+    self.makeFeedRequest( GOOGLE_FEED_URL + "worksheets/" + ss_key + "/private/full/" + worksheet_id, 'DELETE', cb );
   }
 
   this.getRows = function( worksheet_id, opts, cb ){

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ var GooogleSpreadsheet = function( ss_key, auth_id, options ){
 
   this.removeWorksheet = function ( worksheet_id, cb ){
     if (!this.isAuthActive()) return cb(new Error(REQUIRE_AUTH_MESSAGE));
-    self.makeFeedRequest( GOOGLE_FEED_URL + "worksheets/" + ss_key + "/private/full/" + worksheet_id, 'DELETE', cb );
+    self.makeFeedRequest( GOOGLE_FEED_URL + "worksheets/" + ss_key + "/private/full/" + worksheet_id, 'DELETE', {}, cb );
   }
 
   this.getRows = function( worksheet_id, opts, cb ){


### PR DESCRIPTION
Deleting a worksheet is not working, the problem seems to be that the DELETE request is sent to an incorrect URL
`
https://spreadsheets.google.com/feeds/worksheets/key/worksheet_id/private/full
`

the correct being
`
https://spreadsheets.google.com/feeds/worksheets/key/private/full/worksheet_id
`

according to https://developers.google.com/google-apps/spreadsheets/worksheets#delete_a_worksheet
