### PR TITLE
Clearing an empty spreadsheet no longer fails (#100, #104)

### DIFF
--- a/index.js
+++ b/index.js
@@ -394,10 +394,15 @@ var SpreadsheetWorksheet = function( spreadsheet, data ){
     self.resize({rowCount: 1, colCount: 1}, function(err) {
       if (err) return cb(err);
       self.getCells(function(err, cells) {
-        cells[0].setValue(null, function(err) {
-          if (err) return cb(err);
+        if(cells[0]){
+          cells[0].setValue(null, function(err) {
+            if (err) return cb(err);
+            self.resize({rowCount: rows, colCount: cols}, cb);
+          });
+        }else{
+          // Cell was already clear
           self.resize({rowCount: rows, colCount: cols}, cb);
-        });
+        }
       })
     });
   }
@@ -658,6 +663,3 @@ var xmlSafeColumnName = function(val){
   return String(val).replace(/[\s_]+/g, '')
       .toLowerCase();
 }
-
-
-


### PR DESCRIPTION
Calling clear twice on a spreadsheet would fail, because it would attempt to call setValue on an already empty cell.
