### PR TITLE
#128 LF and CR in SpreadsheetCell.save

### DIFF
--- a/index.js
+++ b/index.js
@@ -651,7 +651,9 @@ var xmlSafeValue = function(val){
   return String(val).replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+      .replace(/"/g, '&quot;')
+      .replace(/\n/g,'&#10;')
+      .replace(/\r/g,'&#13;');
 }
 var xmlSafeColumnName = function(val){
   if (!val) return '';

--- a/test/cells-test.js
+++ b/test/cells-test.js
@@ -155,6 +155,17 @@ describe('Cell-based feeds', function() {
       });
     });
 
+    it('can update a single cell with linefeed in value', function(done) {
+      cell.setValue('HELLO\nWORLD', function(err) {
+        (!err).should.be.true;
+        cell.value.should.equal('HELLO\nWORLD');
+        sheet.getCells({}, function(err, cells) {
+          cells[0].value.should.equal('HELLO\nWORLD');
+          done(err);
+        });
+      });
+    });
+
     it('supports `value` to numeric values', function(done) {
       cell.value = 123;
       cell.value.should.equal('123');


### PR DESCRIPTION
Problem: LF and CF symbols are not escaped properly when saving distinct cells #128 

Solution: add two more replacements in `xmlSafeValue` function:

```
String(val)
  .replace(/\n/g,'&#10;')
  .replace(/\r/g,'&#13;')
```
