### PR TITLE
Fix/add row invalid response handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,6 +315,8 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
     data_xml += '</entry>';
     self.makeFeedRequest( ["list", ss_key, worksheet_id], 'POST', data_xml, function(err, data, new_xml) {
       if (err) return cb(err);
+      if (!new_xml) cb(new Error('Invalid response'));
+
       var entries_xml = new_xml.match(/<entry[^>]*>([\s\S]*?)<\/entry>/g);
       var row;
       if (entries_xml !== null) {

--- a/index.js
+++ b/index.js
@@ -316,7 +316,12 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
     self.makeFeedRequest( ["list", ss_key, worksheet_id], 'POST', data_xml, function(err, data, new_xml) {
       if (err) return cb(err);
       var entries_xml = new_xml.match(/<entry[^>]*>([\s\S]*?)<\/entry>/g);
-      var row = new SpreadsheetRow(self, data, entries_xml[0]);
+      var row;
+      if (entries_xml.length > 0) {
+        row = new SpreadsheetRow(self, data, entries_xml[0]);
+      } else {
+        cb(new Error('Invalid response'));
+      }
       cb(null, row);
     });
   }

--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
       if (err) return cb(err);
       var entries_xml = new_xml.match(/<entry[^>]*>([\s\S]*?)<\/entry>/g);
       var row;
-      if (entries_xml.length > 0) {
+      if (entries_xml !== null) {
         row = new SpreadsheetRow(self, data, entries_xml[0]);
       } else {
         cb(new Error('Invalid response'));

--- a/index.js
+++ b/index.js
@@ -315,7 +315,10 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
     data_xml += '</entry>';
     self.makeFeedRequest( ["list", ss_key, worksheet_id], 'POST', data_xml, function(err, data, new_xml) {
       if (err) return cb(err);
-      if (!new_xml) cb(new Error('Invalid response'));
+      if (!new_xml) {
+        cb(new Error('Invalid response'));
+        return;
+      }
 
       var entries_xml = new_xml.match(/<entry[^>]*>([\s\S]*?)<\/entry>/g);
       var row;

--- a/index.js
+++ b/index.js
@@ -326,6 +326,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
         row = new SpreadsheetRow(self, data, entries_xml[0]);
       } else {
         cb(new Error('Invalid response'));
+        return;
       }
       cb(null, row);
     });


### PR DESCRIPTION
I observed that sometimes Google Sheets API returns an unexpected response such as "302: Moved Temporarily". Retrying often succeeds though. Even though I don't know the root cause of this issue, I have added some error handling here. I was able to retry after a failure without a crash. Thanks!