### PR TITLE
Fix misplaced parenthesis

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
             return cb( new Error("Invalid authorization key."));
           } else if ( response.statusCode >= 400 ) {
             var message = _.isObject(body) ? JSON.stringify(body) : body.replace(/&quot;/g, '"');
-            return cb( new Error("HTTP error "+response.statusCode+" ("+http.STATUS_CODES[response.statusCode])+") - "+message);
+            return cb( new Error("HTTP error " + response.statusCode+" (" + http.STATUS_CODES[response.statusCode] + ") - " + message));
           } else if ( response.statusCode === 200 && response.headers['content-type'].indexOf('text/html') >= 0 ) {
             return cb( new Error("Sheet is private. Use authentication or make public. (see https://github.com/theoephraim/node-google-spreadsheet#a-note-on-authentication for details)"));
           }


### PR DESCRIPTION
Misplaced parenthesis causes Error object to be concatenated with a
string rather than passing concatenated string to the Error constructor.
This will result in a string being passed to the callback rather than
an Error object.