### PR TITLE
Added OAuth2 support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,36 @@ Internally, this uses a JWT client to generate a new auth token for your service
 
 
 
+#### `GoogleSpreadsheet.useOAuthClient(oauth2Client, callback)`
+Uses OAuth2 origin `googleapis` client to get access.  
+
+```javascript
+var google = require('googleapis');
+var OAuth2 = google.auth.OAuth2;
+var oauth2Client = new OAuth2(
+    'client_id...here...',
+   'client_secret...here...',
+   '...redirect_uri....'
+);
+
+oauth2Client.setCredentials({
+    refresh_token: '.....refresh_token.....'
+});
+
+
+const doc = new GoogleSpreadsheet('...Bb3oHsOcF......your.spreadsheet.id.....');
+doc.useOAuthClient(oauth2Client, function (err) {
+    
+    // use your doc here....
+    doc.getInfo(function (err, res) {
+        console.log(err, res)
+    });
+});
+
+```
+
+
+
 #### `GoogleSpreadsheet.setAuthToken(id)`
 
 Use an already created auth token for all future requets.

--- a/index.js
+++ b/index.js
@@ -65,6 +65,24 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
     renewJwtAuth(cb);
   }
 
+  this.useOAuthClient = function (OAuthClient, cb) {
+    OAuthClient.refreshAccessToken(function (err, tokens) {
+      if (err) {
+        return cb(err);
+      }
+
+      auth_mode = 'OAuth2';
+
+      setAuthAndDependencies({
+        value: tokens.access_token,
+        type: tokens.token_type,
+        expires: tokens.expiry_date
+      });
+
+      cb();
+    });
+  }
+
   function renewJwtAuth(cb) {
     auth_mode = 'jwt';
     jwt_client.authorize(function (err, token) {


### PR DESCRIPTION
#### `GoogleSpreadsheet.useOAuthClient(oauth2Client, callback)`
Uses OAuth2 origin `googleapis` client to get access.  

```javascript
var google = require('googleapis');
var OAuth2 = google.auth.OAuth2;
var oauth2Client = new OAuth2(
    'client_id...here...',
   'client_secret...here...',
   '...redirect_uri....'
);

oauth2Client.setCredentials({
    refresh_token: '.....refresh_token.....'
});


const doc = new GoogleSpreadsheet('...Bb3oHsOcF......your.spreadsheet.id.....');
doc.useOAuthClient(oauth2Client, function (err) {
    
    // use your doc here....
    doc.getInfo(function (err, res) {
        console.log(err, res)
    });
});

```
