### PR TITLE
Reduce memory footprint

### DIFF
--- a/index.js
+++ b/index.js
@@ -701,10 +701,9 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
       }
 
 
+GoogleSpreadsheet.SpreadsheetCell = SpreadsheetCell;
 
-  init();
-  return self;
-}
+
 
 module.exports = GoogleSpreadsheet;
 

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
       colCount: 20
     };
 
-    var opts = _.extend({}, defaults, opts);
+    opts = _.extend({}, defaults, opts);
 
     // if column headers are set, make sure the sheet is big enough for them
     if (opts.headers && opts.headers.length > opts.colCount) {

--- a/index.js
+++ b/index.js
@@ -605,33 +605,37 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         this.save(cb);
       };
 
-  self.__defineGetter__('value', function(){
-    return self._value;
-  });
-  self.__defineSetter__('value', function(val){
-    if (!val) return self._clearValue();
     SpreadsheetCell.prototype._clearValue = function() {
         this._formula = undefined;
         this._numericValue = undefined;
         this._value = '';
       }
 
-    var numeric_val = parseFloat(val);
-    if (!isNaN(numeric_val)){
-      self._numericValue = numeric_val;
-      self._value = val.toString();
-    } else {
-      self._numericValue = undefined;
-      self._value = val;
-    }
+    Object.defineProperty(SpreadsheetCell.prototype, "value", {
+        get: function(){
+            return this._value;
+        },
+        set: function(val){
+            if (!val) return this._clearValue();
 
-    if (typeof val == 'string' && val.substr(0,1) === '=') {
-      // use the getter to clear the value
-      self.formula = val;
-    } else {
-      self._formula = undefined;
-    }
-  });
+            var numeric_val = parseFloat(val);
+            if (!isNaN(numeric_val)){
+                this._numericValue = numeric_val;
+                this._value = val.toString();
+            } else {
+                this._numericValue = undefined;
+                this._value = val;
+            }
+
+            if (typeof val == 'string' && val.substr(0,1) === '=') {
+                // use the getter to clear the value
+                this.formula = val;
+            } else {
+                this._formula = undefined;
+            }
+        }
+    });
+
 
   self.__defineGetter__('formula', function() {
     return self._formula;

--- a/index.js
+++ b/index.js
@@ -669,10 +669,12 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
     });
 
+    Object.defineProperty(SpreadsheetCell.prototype, "valueForSave", {
+        get: function() {
+            return xmlSafeValue(this._formula || this._value);
+        }
+    });
 
-  self.__defineGetter__('valueForSave', function() {
-    return xmlSafeValue(self._formula || self._value);
-  });
 
   self.save = function(cb) {
     if ( !cb ) cb = function(){};

--- a/index.js
+++ b/index.js
@@ -352,8 +352,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
       var cells = [];
       var entries = forceArray(data['entry']);
-      var data = null;
-      var i = 0;
+      data = null;
       while(entries.length > 0) {
         cells.push( new SpreadsheetCell( self, ss_key, worksheet_id, entries.shift() ) );
       }

--- a/index.js
+++ b/index.js
@@ -528,182 +528,179 @@ var SpreadsheetRow = function( spreadsheet, data, xml ){
 }
 
 function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
-    var links;
-    this.row = parseInt(data['gs:cell']['$']['row']);
-    this.col = parseInt(data['gs:cell']['$']['col']);
-    this.batchId = 'R'+this.row+'C'+this.col;
-    if(data['id'] == "https://spreadsheets.google.com/feeds/cells/" + ss_key + "/" + worksheet_id + '/' + this.batchId) {
-      this.ws_id = worksheet_id;
-      this.ss = ss_key;
-    }else{
-      this.id = data['id'];
-    }
+  var links;
+  this.row = parseInt(data['gs:cell']['$']['row']);
+  this.col = parseInt(data['gs:cell']['$']['col']);
+  this.batchId = 'R'+this.row+'C'+this.col;
+  if(data['id'] == "https://spreadsheets.google.com/feeds/cells/" + ss_key + "/" + worksheet_id + '/' + this.batchId) {
+    this.ws_id = worksheet_id;
+    this.ss = ss_key;
+  }else{
+    this.id = data['id'];
+  }
 
-    this['_links'] = [];
-    links = forceArray( data.link );
-    for (var i = 0; i < links.length; i++) {
-      link = links[i];
-      if(link['$']['rel'] == "self" && link['$']['href'] == this.getSelf()) continue;
-      if(link['$']['rel'] == "edit" && link['$']['href'] == this.getEdit()) continue;
-      this['_links'][ link['$']['rel'] ] = link['$']['href'];
-    };
-    if(this['_links'].length == 0) delete this['_links'];
+  this['_links'] = [];
+  links = forceArray( data.link );
+  for (var i = 0; i < links.length; i++) {
+    link = links[i];
+    if(link['$']['rel'] == "self" && link['$']['href'] == this.getSelf()) continue;
+    if(link['$']['rel'] == "edit" && link['$']['href'] == this.getEdit()) continue;
+    this['_links'][ link['$']['rel'] ] = link['$']['href'];
+  };
+  if(this['_links'].length == 0) delete this['_links'];
 
-    this.updateValuesFromResponseData(data);
+  this.updateValuesFromResponseData(data);
 
-    return this;
+  return this;
 };
 
-    SpreadsheetCell.prototype.getId = function() {
-        if(!!this.id) {
-          return this.id;
-        } else {
-          return "https://spreadsheets.google.com/feeds/cells/" + this.ss + "/" + this.ws_id + '/' + this.batchId;
-        }
-      }
+SpreadsheetCell.prototype.getId = function() {
+  if(!!this.id) {
+    return this.id;
+  } else {
+    return "https://spreadsheets.google.com/feeds/cells/" + this.ss + "/" + this.ws_id + '/' + this.batchId;
+  }
+}
 
-    SpreadsheetCell.prototype.getEdit = function() {
-        if(!!this['_links'] && !!this['_links']['edit']) {
-          return this['_links']['edit'];
-        } else {
-          return this.getId().replace(this.batchId, "private/full/" + this.batchId);
-        }
-      }
+SpreadsheetCell.prototype.getEdit = function() {
+  if(!!this['_links'] && !!this['_links']['edit']) {
+    return this['_links']['edit'];
+  } else {
+    return this.getId().replace(this.batchId, "private/full/" + this.batchId);
+  }
+}
 
-    SpreadsheetCell.prototype.getSelf = function() {
-        if(!!this['_links'] && !!this['_links']['edit']) {
-          return this['_links']['edit'];
-        } else {
-          return this.getId().replace(this.batchId, "private/full/" + this.batchId);
-        }
-      }
+SpreadsheetCell.prototype.getSelf = function() {
+  if(!!this['_links'] && !!this['_links']['edit']) {
+    return this['_links']['edit'];
+  } else {
+    return this.getId().replace(this.batchId, "private/full/" + this.batchId);
+  }
+}
 
-    SpreadsheetCell.prototype.updateValuesFromResponseData = function(_data) {
-        // formula value
-        var input_val = _data['gs:cell']['$']['inputValue'];
-        // inputValue can be undefined so substr throws an error
-        // still unsure how this situation happens
-        if (input_val && input_val.substr(0,1) === '='){
-          this._formula = input_val;
-        } else {
-          this._formula = undefined;
-        }
+SpreadsheetCell.prototype.updateValuesFromResponseData = function(_data) {
+  // formula value
+  var input_val = _data['gs:cell']['$']['inputValue'];
+  // inputValue can be undefined so substr throws an error
+  // still unsure how this situation happens
+  if (input_val && input_val.substr(0,1) === '='){
+    this._formula = input_val;
+  } else {
+    this._formula = undefined;
+  }
 
-        // numeric values
-        if (_data['gs:cell']['$']['numericValue'] !== undefined) {
-          this._numericValue = parseFloat(_data['gs:cell']['$']['numericValue']);
-        } else {
-          this._numericValue = undefined;
-        }
+  // numeric values
+  if (_data['gs:cell']['$']['numericValue'] !== undefined) {
+    this._numericValue = parseFloat(_data['gs:cell']['$']['numericValue']);
+  } else {
+    this._numericValue = undefined;
+  }
 
-        // the main "value" - its always a string
-        this._value = _data['gs:cell']['_'] || '';
-      }
+  // the main "value" - its always a string
+  this._value = _data['gs:cell']['_'] || '';
+}
 
-    SpreadsheetCell.prototype.setValue = function(new_value, cb) {
-        this.value = new_value;
-        this.save(cb);
-      };
+SpreadsheetCell.prototype.setValue = function(new_value, cb) {
+  this.value = new_value;
+  this.save(cb);
+};
 
-    SpreadsheetCell.prototype._clearValue = function() {
-        this._formula = undefined;
-        this._numericValue = undefined;
-        this._value = '';
-      }
+SpreadsheetCell.prototype._clearValue = function() {
+  this._formula = undefined;
+  this._numericValue = undefined;
+  this._value = '';
+}
 
-    Object.defineProperty(SpreadsheetCell.prototype, "value", {
-        get: function(){
-            return this._value;
-        },
-        set: function(val){
-            if (!val) return this._clearValue();
+Object.defineProperty(SpreadsheetCell.prototype, "value", {
+  get: function(){
+    return this._value;
+  },
+  set: function(val){
+    if (!val) return this._clearValue();
 
-            var numeric_val = parseFloat(val);
-            if (!isNaN(numeric_val)){
-                this._numericValue = numeric_val;
-                this._value = val.toString();
-            } else {
-                this._numericValue = undefined;
-                this._value = val;
-            }
+    var numeric_val = parseFloat(val);
+    if (!isNaN(numeric_val)){
+      this._numericValue = numeric_val;
+      this._value = val.toString();
+    } else {
+      this._numericValue = undefined;
+      this._value = val;
+    }
 
-            if (typeof val == 'string' && val.substr(0,1) === '=') {
-                // use the getter to clear the value
-                this.formula = val;
-            } else {
-                this._formula = undefined;
-            }
-        }
-    });
+    if (typeof val == 'string' && val.substr(0,1) === '=') {
+      // use the getter to clear the value
+      this.formula = val;
+    } else {
+      this._formula = undefined;
+    }
+  }
+});
 
-    Object.defineProperty(SpreadsheetCell.prototype, "formula", {
-        get: function() {
-            return this._formula;
-        },
-        set: function(val){
-            if (!val) return this._clearValue();
+Object.defineProperty(SpreadsheetCell.prototype, "formula", {
+  get: function() {
+    return this._formula;
+  },
+  set: function(val){
+    if (!val) return this._clearValue();
 
-            if (val.substr(0,1) !== '=') {
-              throw new Error('Formulas must start with "="');
-            }
-            this._numericValue = undefined;
-            this._value = '*SAVE TO GET NEW VALUE*';
-            this._formula = val;
-        }
-    });
+    if (val.substr(0,1) !== '=') {
+      throw new Error('Formulas must start with "="');
+    }
+    this._numericValue = undefined;
+    this._value = '*SAVE TO GET NEW VALUE*';
+    this._formula = val;
+  }
+});
 
-    Object.defineProperty(SpreadsheetCell.prototype, "numericValue", {
-        get: function() {
-            return this._numericValue;
-        },
-        set: function(val) {
-            if (val === undefined || val === null) return this._clearValue();
+Object.defineProperty(SpreadsheetCell.prototype, "numericValue", {
+  get: function() {
+    return this._numericValue;
+  },
+  set: function(val) {
+    if (val === undefined || val === null) return this._clearValue();
 
-            if (isNaN(parseFloat(val)) || !isFinite(val)) {
-              throw new Error('Invalid numeric value assignment');
-            }
+    if (isNaN(parseFloat(val)) || !isFinite(val)) {
+      throw new Error('Invalid numeric value assignment');
+    }
 
-            this._value = val.toString();
-            this._numericValue = parseFloat(val);
-            this._formula = undefined;
-        }
-    });
+    this._value = val.toString();
+    this._numericValue = parseFloat(val);
+    this._formula = undefined;
+  }
+});
 
-    Object.defineProperty(SpreadsheetCell.prototype, "valueForSave", {
-        get: function() {
-            return xmlSafeValue(this._formula || this._value);
-        }
-    });
+Object.defineProperty(SpreadsheetCell.prototype, "valueForSave", {
+  get: function() {
+    return xmlSafeValue(this._formula || this._value);
+  }
+});
 
-    SpreadsheetCell.prototype.save = function(cb) {
-        if ( !cb ) cb = function(){};
-        this._needsSave = false;
+SpreadsheetCell.prototype.save = function(cb) {
+  if ( !cb ) cb = function(){};
+  this._needsSave = false;
 
-        var edit_id = 'https://spreadsheets.google.com/feeds/cells/key/worksheetId/private/full/R'+this.row+'C'+this.col;
-        var data_xml =
-          '<entry><id>'+this.getId()+'</id>'+
-          '<link rel="edit" type="application/atom+xml" href="'+this.getId()+'"/>'+
-          '<gs:cell row="'+this.row+'" col="'+this.col+'" inputValue="'+this.valueForSave+'"/></entry>'
+  var edit_id = 'https://spreadsheets.google.com/feeds/cells/key/worksheetId/private/full/R'+this.row+'C'+this.col;
+  var data_xml =
+    '<entry><id>'+this.getId()+'</id>'+
+    '<link rel="edit" type="application/atom+xml" href="'+this.getId()+'"/>'+
+    '<gs:cell row="'+this.row+'" col="'+this.col+'" inputValue="'+this.valueForSave+'"/></entry>'
 
-        data_xml = data_xml.replace('<entry>', "<entry xmlns='http://www.w3.org/2005/Atom' xmlns:gs='http://schemas.google.com/spreadsheets/2006'>");
+  data_xml = data_xml.replace('<entry>', "<entry xmlns='http://www.w3.org/2005/Atom' xmlns:gs='http://schemas.google.com/spreadsheets/2006'>");
 
-        var self = this;
+  var self = this;
 
-        spreadsheet.makeFeedRequest( this.getEdit(), 'PUT', data_xml, function(err, response) {
-          if (err) return cb(err);
-          self.updateValuesFromResponseData(response);
-          cb();
-        });
-      }
+  spreadsheet.makeFeedRequest( this.getEdit(), 'PUT', data_xml, function(err, response) {
+    if (err) return cb(err);
+    self.updateValuesFromResponseData(response);
+    cb();
+  });
+}
 
-    SpreadsheetCell.prototype.del = function(cb) {
-        this.setValue('', cb);
-      }
-
+SpreadsheetCell.prototype.del = function(cb) {
+  this.setValue('', cb);
+}
 
 GoogleSpreadsheet.SpreadsheetCell = SpreadsheetCell;
-
-
 
 module.exports = GoogleSpreadsheet;
 

--- a/index.js
+++ b/index.js
@@ -528,6 +528,7 @@ var SpreadsheetRow = function( spreadsheet, data, xml ){
 
 function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
   var links;
+  this.spreadsheet = spreadsheet;
   this.row = parseInt(data['gs:cell']['$']['row']);
   this.col = parseInt(data['gs:cell']['$']['col']);
   this.batchId = 'R'+this.row+'C'+this.col;
@@ -688,7 +689,7 @@ SpreadsheetCell.prototype.save = function(cb) {
 
   var self = this;
 
-  spreadsheet.makeFeedRequest( this.getEdit(), 'PUT', data_xml, function(err, response) {
+  this.spreadsheet.makeFeedRequest( this.getEdit(), 'PUT', data_xml, function(err, response) {
     if (err) return cb(err);
     self.updateValuesFromResponseData(response);
     cb();

--- a/index.js
+++ b/index.js
@@ -26,12 +26,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
   options = options || {};
 
-  var xml_parser = new xml2js.Parser({
-    // options carried over from older version of xml2js
-    // might want to update how the code works, but for now this is fine
-    explicitArray: false,
-    explicitRoot: false
-  });
+
 
   if ( !ss_key ) {
     throw new Error("Spreadsheet key not provided.");
@@ -162,8 +157,18 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
 
           if ( body ){
+            var xml_parser = new xml2js.Parser({
+              // options carried over from older version of xml2js
+              // might want to update how the code works, but for now this is fine
+              explicitArray: false,
+              explicitRoot: false
+            });
             xml_parser.parseString(body, function(err, result){
-              if ( err ) return cb( err );
+              if ( err ) {
+                xml_parser = null;
+                body = null;
+                return cb( err );
+              }
               if(cb.length == 3) {
                 cb( null, result, body );
               }else{

--- a/index.js
+++ b/index.js
@@ -636,20 +636,22 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
     });
 
+    Object.defineProperty(SpreadsheetCell.prototype, "formula", {
+        get: function() {
+            return this._formula;
+        },
+        set: function(val){
+            if (!val) return this._clearValue();
 
-  self.__defineGetter__('formula', function() {
-    return self._formula;
-  });
-  self.__defineSetter__('formula', function(val){
-    if (!val) return self._clearValue();
+            if (val.substr(0,1) !== '=') {
+              throw new Error('Formulas must start with "="');
+            }
+            this._numericValue = undefined;
+            this._value = '*SAVE TO GET NEW VALUE*';
+            this._formula = val;
+        }
+    });
 
-    if (val.substr(0,1) !== '=') {
-      throw new Error('Formulas must start with "="');
-    }
-    self._numericValue = undefined;
-    self._value = '*SAVE TO GET NEW VALUE*';
-    self._formula = val;
-  });
 
   self.__defineGetter__('numericValue', function() {
     return self._numericValue;

--- a/index.js
+++ b/index.js
@@ -554,13 +554,6 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
     return this;
 };
 
-  self.getEdit = function() {
-    if(!!self['_links'] && !!self['_links']['edit']) {
-      return self['_links']['edit'];
-    } else {
-      return self.getId().replace(self.batchId, "private/full/" + self.batchId);
-    }
-  }
     SpreadsheetCell.prototype.getId = function() {
         if(!!this.id) {
           return this.id;
@@ -576,6 +569,13 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
       return self.getId().replace(self.batchId, "private/full/" + self.batchId);
     }
   }
+    SpreadsheetCell.prototype.getEdit = function() {
+        if(!!this['_links'] && !!this['_links']['edit']) {
+          return this['_links']['edit'];
+        } else {
+          return this.getId().replace(this.batchId, "private/full/" + this.batchId);
+        }
+      }
 
   self.updateValuesFromResponseData = function(_data) {
     // formula value

--- a/index.js
+++ b/index.js
@@ -551,13 +551,6 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
 
     this.updateValuesFromResponseData(data);
 
-  self.getId = function() {
-    if(!!self.id) {
-      return self.id;
-    } else {
-      return "https://spreadsheets.google.com/feeds/cells/" + self.ss + "/" + self.ws_id + '/' + self.batchId;
-    }
-  }
     return this;
 };
 
@@ -568,6 +561,13 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
       return self.getId().replace(self.batchId, "private/full/" + self.batchId);
     }
   }
+    SpreadsheetCell.prototype.getId = function() {
+        if(!!this.id) {
+          return this.id;
+        } else {
+          return "https://spreadsheets.google.com/feeds/cells/" + this.ss + "/" + this.ws_id + '/' + this.batchId;
+        }
+      }
 
   self.getSelf = function() {
     if(!!self['_links'] && !!self['_links']['edit']) {

--- a/index.js
+++ b/index.js
@@ -542,17 +542,17 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
   this['_links'] = [];
   links = forceArray( data.link );
   for (var i = 0; i < links.length; i++) {
-    link = links[i];
+    var link = links[i];
     if(link['$']['rel'] == "self" && link['$']['href'] == this.getSelf()) continue;
     if(link['$']['rel'] == "edit" && link['$']['href'] == this.getEdit()) continue;
     this['_links'][ link['$']['rel'] ] = link['$']['href'];
-  };
+  }
   if(this['_links'].length == 0) delete this['_links'];
 
   this.updateValuesFromResponseData(data);
 
   return this;
-};
+}
 
 SpreadsheetCell.prototype.getId = function() {
   if(!!this.id) {
@@ -679,7 +679,6 @@ SpreadsheetCell.prototype.save = function(cb) {
   if ( !cb ) cb = function(){};
   this._needsSave = false;
 
-  var edit_id = 'https://spreadsheets.google.com/feeds/cells/key/worksheetId/private/full/R'+this.row+'C'+this.col;
   var data_xml =
     '<entry><id>'+this.getId()+'</id>'+
     '<link rel="edit" type="application/atom+xml" href="'+this.getId()+'"/>'+

--- a/index.js
+++ b/index.js
@@ -604,17 +604,17 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
     self.save(cb);
   };
 
-  self._clearValue = function() {
-    self._formula = undefined;
-    self._numericValue = undefined;
-    self._value = '';
-  }
 
   self.__defineGetter__('value', function(){
     return self._value;
   });
   self.__defineSetter__('value', function(val){
     if (!val) return self._clearValue();
+    SpreadsheetCell.prototype._clearValue = function() {
+        this._formula = undefined;
+        this._numericValue = undefined;
+        this._value = '';
+      }
 
     var numeric_val = parseFloat(val);
     if (!isNaN(numeric_val)){

--- a/index.js
+++ b/index.js
@@ -599,11 +599,11 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
     self._value = _data['gs:cell']['_'] || '';
   }
 
-  self.setValue = function(new_value, cb) {
-    self.value = new_value;
-    self.save(cb);
-  };
 
+    SpreadsheetCell.prototype.setValue = function(new_value, cb) {
+        this.value = new_value;
+        this.save(cb);
+      };
 
   self.__defineGetter__('value', function(){
     return self._value;

--- a/index.js
+++ b/index.js
@@ -675,25 +675,27 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
     });
 
+    SpreadsheetCell.prototype.save = function(cb) {
+        if ( !cb ) cb = function(){};
+        this._needsSave = false;
 
-  self.save = function(cb) {
-    if ( !cb ) cb = function(){};
-    self._needsSave = false;
+        var edit_id = 'https://spreadsheets.google.com/feeds/cells/key/worksheetId/private/full/R'+this.row+'C'+this.col;
+        var data_xml =
+          '<entry><id>'+this.getId()+'</id>'+
+          '<link rel="edit" type="application/atom+xml" href="'+this.getId()+'"/>'+
+          '<gs:cell row="'+this.row+'" col="'+this.col+'" inputValue="'+this.valueForSave+'"/></entry>'
 
-    var edit_id = 'https://spreadsheets.google.com/feeds/cells/key/worksheetId/private/full/R'+self.row+'C'+self.col;
-    var data_xml =
-      '<entry><id>'+self.getId()+'</id>'+
-      '<link rel="edit" type="application/atom+xml" href="'+self.getId()+'"/>'+
-      '<gs:cell row="'+self.row+'" col="'+self.col+'" inputValue="'+self.valueForSave+'"/></entry>'
+        data_xml = data_xml.replace('<entry>', "<entry xmlns='http://www.w3.org/2005/Atom' xmlns:gs='http://schemas.google.com/spreadsheets/2006'>");
 
-    data_xml = data_xml.replace('<entry>', "<entry xmlns='http://www.w3.org/2005/Atom' xmlns:gs='http://schemas.google.com/spreadsheets/2006'>");
+        var self = this;
 
-    spreadsheet.makeFeedRequest( self.getEdit(), 'PUT', data_xml, function(err, response) {
-      if (err) return cb(err);
-      self.updateValuesFromResponseData(response);
-      cb();
-    });
-  }
+        spreadsheet.makeFeedRequest( this.getEdit(), 'PUT', data_xml, function(err, response) {
+          if (err) return cb(err);
+          self.updateValuesFromResponseData(response);
+          cb();
+        });
+      }
+
     SpreadsheetCell.prototype.del = function(cb) {
         this.setValue('', cb);
       }

--- a/index.js
+++ b/index.js
@@ -163,9 +163,13 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
           if ( body ){
             xml_parser.parseString(body, function(err, result){
-              body = null;
               if ( err ) return cb( err );
-              cb( null, result );
+              if(cb.length == 3) {
+                cb( null, result, body );
+              }else{
+                body = null;
+                cb( null, result );
+              }
             });
           } else {
             if ( err ) cb( err );
@@ -180,7 +184,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
   // public API methods
   this.getInfo = function( cb ){
-    self.makeFeedRequest( ["worksheets", ss_key], 'GET', null, function(err, data, xml) {
+    self.makeFeedRequest( ["worksheets", ss_key], 'GET', null, function(err, data) {
       if ( err ) return cb( err );
       if (data===true) {
         return cb(new Error('No response to getInfo call'))
@@ -236,7 +240,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
         opts.colCount +
       '</gs:colCount></entry>';
 
-    self.makeFeedRequest( ["worksheets", ss_key], 'POST', data_xml, function(err, data, xml) {
+    self.makeFeedRequest( ["worksheets", ss_key], 'POST', data_xml, function(err, data) {
       if ( err ) return cb( err );
 
       var sheet = new SpreadsheetWorksheet( self, data );
@@ -335,7 +339,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
     var query = _.assign({}, opts);
 
 
-    self.makeFeedRequest(["cells", ss_key, worksheet_id], 'GET', query, function (err, data, xml) {
+    self.makeFeedRequest(["cells", ss_key, worksheet_id], 'GET', query, function (err, data) {
       if (err) return cb(err);
       if (data===true) {
         return cb(new Error('No response to getCells call'))
@@ -343,6 +347,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
       var cells = [];
       var entries = forceArray(data['entry']);
+      var data = null;
       var i = 0;
       while(entries.length > 0) {
         cells.push( new SpreadsheetCell( self, ss_key, worksheet_id, entries.shift() ) );

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
       var entries = forceArray(data['entry']);
       var i = 0;
       while(entries.length > 0) {
-        cells.push( new SpreadsheetCell( self, worksheet_id, entries.shift() ) );
+        cells.push( new SpreadsheetCell( self, ss_key, worksheet_id, entries.shift() ) );
       }
 
       cb( null, cells );
@@ -516,15 +516,20 @@ var SpreadsheetRow = function( spreadsheet, data, xml ){
   }
 }
 
-var SpreadsheetCell = function( spreadsheet, worksheet_id, data ){
+var SpreadsheetCell = function( spreadsheet, ss_key, worksheet_id, data ){
   var self = this;
 
   function init() {
     var links;
-    self.id = data['id'];
     self.row = parseInt(data['gs:cell']['$']['row']);
     self.col = parseInt(data['gs:cell']['$']['col']);
     self.batchId = 'R'+self.row+'C'+self.col;
+    if(data['id'] == "https://spreadsheets.google.com/feeds/cells/" + ss_key + "/" + worksheet_id + '/' + self.batchId) {
+      self.ws_id = worksheet_id;
+      self.ss = ss_key;
+    }else{
+      self.id = data['id'];
+    }
 
     self['_links'] = [];
     links = forceArray( data.link );
@@ -539,7 +544,11 @@ var SpreadsheetCell = function( spreadsheet, worksheet_id, data ){
   }
 
   self.getId = function() {
+    if(!!self.id) {
       return self.id;
+    } else {
+      return "https://spreadsheets.google.com/feeds/cells/" + self.ss + "/" + self.ws_id + '/' + self.batchId;
+    }
   }
 
   self.getEdit = function() {

--- a/index.js
+++ b/index.js
@@ -343,9 +343,9 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
       var cells = [];
       var entries = forceArray(data['entry']);
       var i = 0;
-      entries.forEach(function( cell_data ){
-        cells.push( new SpreadsheetCell( self, worksheet_id, cell_data ) );
-      });
+      while(entries.length > 0) {
+        cells.push( new SpreadsheetCell( self, worksheet_id, entries.shift() ) );
+      }
 
       cb( null, cells );
     });

--- a/index.js
+++ b/index.js
@@ -570,16 +570,6 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
       }
 
-  self.updateValuesFromResponseData = function(_data) {
-    // formula value
-    var input_val = _data['gs:cell']['$']['inputValue'];
-    // inputValue can be undefined so substr throws an error
-    // still unsure how this situation happens
-    if (input_val && input_val.substr(0,1) === '='){
-      self._formula = input_val;
-    } else {
-      self._formula = undefined;
-    }
     SpreadsheetCell.prototype.getSelf = function() {
         if(!!this['_links'] && !!this['_links']['edit']) {
           return this['_links']['edit'];
@@ -588,17 +578,27 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
       }
 
-    // numeric values
-    if (_data['gs:cell']['$']['numericValue'] !== undefined) {
-      self._numericValue = parseFloat(_data['gs:cell']['$']['numericValue']);
-    } else {
-      self._numericValue = undefined;
-    }
+    SpreadsheetCell.prototype.updateValuesFromResponseData = function(_data) {
+        // formula value
+        var input_val = _data['gs:cell']['$']['inputValue'];
+        // inputValue can be undefined so substr throws an error
+        // still unsure how this situation happens
+        if (input_val && input_val.substr(0,1) === '='){
+          this._formula = input_val;
+        } else {
+          this._formula = undefined;
+        }
 
-    // the main "value" - its always a string
-    self._value = _data['gs:cell']['_'] || '';
-  }
+        // numeric values
+        if (_data['gs:cell']['$']['numericValue'] !== undefined) {
+          this._numericValue = parseFloat(_data['gs:cell']['$']['numericValue']);
+        } else {
+          this._numericValue = undefined;
+        }
 
+        // the main "value" - its always a string
+        this._value = _data['gs:cell']['_'] || '';
+      }
 
     SpreadsheetCell.prototype.setValue = function(new_value, cb) {
         this.value = new_value;

--- a/index.js
+++ b/index.js
@@ -694,10 +694,11 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
       cb();
     });
   }
+    SpreadsheetCell.prototype.del = function(cb) {
+        this.setValue('', cb);
+      }
 
-  self.del = function(cb) {
-    self.setValue('', cb);
-  }
+
 
   init();
   return self;

--- a/index.js
+++ b/index.js
@@ -562,13 +562,6 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
       }
 
-  self.getSelf = function() {
-    if(!!self['_links'] && !!self['_links']['edit']) {
-      return self['_links']['edit'];
-    } else {
-      return self.getId().replace(self.batchId, "private/full/" + self.batchId);
-    }
-  }
     SpreadsheetCell.prototype.getEdit = function() {
         if(!!this['_links'] && !!this['_links']['edit']) {
           return this['_links']['edit'];
@@ -587,6 +580,13 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
     } else {
       self._formula = undefined;
     }
+    SpreadsheetCell.prototype.getSelf = function() {
+        if(!!this['_links'] && !!this['_links']['edit']) {
+          return this['_links']['edit'];
+        } else {
+          return this.getId().replace(this.batchId, "private/full/" + this.batchId);
+        }
+      }
 
     // numeric values
     if (_data['gs:cell']['$']['numericValue'] !== undefined) {

--- a/index.js
+++ b/index.js
@@ -162,8 +162,9 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
           if ( body ){
             xml_parser.parseString(body, function(err, result){
+              body = null;
               if ( err ) return cb( err );
-              cb( null, result, body );
+              cb( null, result );
             });
           } else {
             if ( err ) cb( err );

--- a/index.js
+++ b/index.js
@@ -527,32 +527,29 @@ var SpreadsheetRow = function( spreadsheet, data, xml ){
   }
 }
 
-var SpreadsheetCell = function( spreadsheet, ss_key, worksheet_id, data ){
-  var self = this;
-
-  function init() {
+function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
     var links;
-    self.row = parseInt(data['gs:cell']['$']['row']);
-    self.col = parseInt(data['gs:cell']['$']['col']);
-    self.batchId = 'R'+self.row+'C'+self.col;
-    if(data['id'] == "https://spreadsheets.google.com/feeds/cells/" + ss_key + "/" + worksheet_id + '/' + self.batchId) {
-      self.ws_id = worksheet_id;
-      self.ss = ss_key;
+    this.row = parseInt(data['gs:cell']['$']['row']);
+    this.col = parseInt(data['gs:cell']['$']['col']);
+    this.batchId = 'R'+this.row+'C'+this.col;
+    if(data['id'] == "https://spreadsheets.google.com/feeds/cells/" + ss_key + "/" + worksheet_id + '/' + this.batchId) {
+      this.ws_id = worksheet_id;
+      this.ss = ss_key;
     }else{
-      self.id = data['id'];
+      this.id = data['id'];
     }
 
-    self['_links'] = [];
+    this['_links'] = [];
     links = forceArray( data.link );
-    links.forEach( function( link ){
-      if(link['$']['rel'] == "self" && link['$']['href'] == self.getSelf()) return;
-      if(link['$']['rel'] == "edit" && link['$']['href'] == self.getEdit()) return;
-      self['_links'][ link['$']['rel'] ] = link['$']['href'];
-    });
-    if(self['_links'].length == 0) delete self['_links'];
+    for (var i = 0; i < links.length; i++) {
+      link = links[i];
+      if(link['$']['rel'] == "self" && link['$']['href'] == this.getSelf()) continue;
+      if(link['$']['rel'] == "edit" && link['$']['href'] == this.getEdit()) continue;
+      this['_links'][ link['$']['rel'] ] = link['$']['href'];
+    };
+    if(this['_links'].length == 0) delete this['_links'];
 
-    self.updateValuesFromResponseData(data);
-  }
+    this.updateValuesFromResponseData(data);
 
   self.getId = function() {
     if(!!self.id) {
@@ -561,6 +558,8 @@ var SpreadsheetCell = function( spreadsheet, ss_key, worksheet_id, data ){
       return "https://spreadsheets.google.com/feeds/cells/" + self.ss + "/" + self.ws_id + '/' + self.batchId;
     }
   }
+    return this;
+};
 
   self.getEdit = function() {
     if(!!self['_links'] && !!self['_links']['edit']) {

--- a/index.js
+++ b/index.js
@@ -146,6 +146,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
           url: url,
           method: method,
           headers: headers,
+          gzip: true,
           body: method == 'POST' || method == 'PUT' ? query_or_data : null
         }, function(err, response, body){
           if (err) {

--- a/index.js
+++ b/index.js
@@ -652,21 +652,23 @@ function SpreadsheetCell(spreadsheet, ss_key, worksheet_id, data){
         }
     });
 
+    Object.defineProperty(SpreadsheetCell.prototype, "numericValue", {
+        get: function() {
+            return this._numericValue;
+        },
+        set: function(val) {
+            if (val === undefined || val === null) return this._clearValue();
 
-  self.__defineGetter__('numericValue', function() {
-    return self._numericValue;
-  });
-  self.__defineSetter__('numericValue', function(val) {
-    if (val === undefined || val === null) return self._clearValue();
+            if (isNaN(parseFloat(val)) || !isFinite(val)) {
+              throw new Error('Invalid numeric value assignment');
+            }
 
-    if (isNaN(parseFloat(val)) || !isFinite(val)) {
-      throw new Error('Invalid numeric value assignment');
-    }
+            this._value = val.toString();
+            this._numericValue = parseFloat(val);
+            this._formula = undefined;
+        }
+    });
 
-    self._value = val.toString();
-    self._numericValue = parseFloat(val);
-    self._formula = undefined;
-  });
 
   self.__defineGetter__('valueForSave', function() {
     return xmlSafeValue(self._formula || self._value);


### PR DESCRIPTION
This helped me with #140 

Basically we remove the long edit and self links from each cell, and just construct them if necessary. We still save them if they don't match our pattern, so that's a fallback for API/URL changes.

We also unset the raw string return body, and don't pass it on to the callback ( this seemed like an undocumented feature - maybe used previously for debugging purposes? )

Managed to reduce the memory footprint drastically already on sheets with ~25k cells.