### PR TITLE
Fix undefined inputValue error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Theo Ephraim <theozero@gmail.com> (http://theoephraim.com)",
   "name": "google-spreadsheet",
   "description": "Google Spreadsheets Data API -- simple interface to read/write rows/cells, manage sheets",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "Unlicense",
   "keywords": [
     "google spreadsheets",


### PR DESCRIPTION
An undefined `inputValue` (line 539) will be generated if there is a `makeFeedRequest` (line 430) for cell data on a deleted sheet (I assume this is possible because async schedules both the cell update and sheet deletion, but the cell update is scheduled after the deletion).
To solve for this, you can check if a cell `Title` returns `"Error"` and then exclude that cell from the `updateValuesFromResponseData` update.