### PR TITLE
Fixed row save to correctly pick properties and save values containing the "dollar" sign.

### DIFF
--- a/test/rows-test.js
+++ b/test/rows-test.js
@@ -96,6 +96,24 @@ describe('Row-based feeds', function() {
       });
     });
 
+    it('can update a row with string containing "dollar" sign', function(done) {
+      row.col3 = 'Give me $10.';
+      row.save(function(err) {
+        (err == null).should.be.true;
+        done();
+      });
+    });
+
+    it('persisted the value with "dollar" sign', function(done) {
+      sheet.getRows(function(err, rows) {
+        rows.length.should.equal(1);
+        rows[0].col1.should.equal('1');
+        rows[0].col2.should.equal('2');
+        rows[0].col3.should.equal('Give me $10.');
+        done(err);
+      });
+    });
+
     _.each({
       'new lines': "new\n\nlines\n",
       'special chars': "∑πécial <> chårs = !\t"


### PR DESCRIPTION
There is a bug in row "save" method on line https://github.com/theoephraim/node-google-spreadsheet/blob/master/index.js#L518 where brackets are misplaced: 

if (key.substr(0,1) != '_' && typeof( self[key] == 'string') << bracket misplacement

There is another bug in line https://github.com/theoephraim/node-google-spreadsheet/blob/master/index.js#L519 where the String.replace second argument is not escaped. Note that replacer string can contain special $ symbol and that corrupts uploaded value.
See also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter