### PR TITLE
Error handling for when a bulk update is attempted on a protected worksheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ var SpreadsheetWorksheet = function( spreadsheet, data ){
     spreadsheet.makeFeedRequest(self['_links']['bulkcells'], 'POST', data_xml, function(err, data) {
       if (err) return cb(err);
 
-      // looks for an error that in some cases is caused by a protected worksheet
+      // looks for an error that can be caused by a protected worksheet
       if (data.entry && data.entry.length) {
         for (const cell_data of data.entry) {
           if (cell_data['gs:cell'] === undefined) {

--- a/index.js
+++ b/index.js
@@ -441,6 +441,11 @@ var SpreadsheetWorksheet = function( spreadsheet, data ){
     spreadsheet.makeFeedRequest(self['_links']['bulkcells'], 'POST', data_xml, function(err, data) {
       if (err) return cb(err);
 
+      // this looks for an error that in some cases is caused by a protected worksheet
+      if (data.entry && data.entry.length) data.entry.forEach(function(cell_data) {
+        if(cell_data['gs:cell'] === undefined) return cb(new Error('[\'gs:cell\'] is undefined in response data. This may be caused by a protected worksheet.'));
+      });
+
       // update all the cells
       var cells_by_batch_id = _.keyBy(cells, 'batchId');
       if (data.entry && data.entry.length) data.entry.forEach(function(cell_data) {

--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ var SpreadsheetWorksheet = function( spreadsheet, data ){
     spreadsheet.makeFeedRequest(self['_links']['bulkcells'], 'POST', data_xml, function(err, data) {
       if (err) return cb(err);
 
-      // this looks for an error that in some cases is caused by a protected worksheet
+      // looks for an error that in some cases is caused by a protected worksheet
       if (data.entry && data.entry.length) {
         for (const cell_data of data.entry) {
           if (cell_data['gs:cell'] === undefined) {

--- a/index.js
+++ b/index.js
@@ -442,9 +442,13 @@ var SpreadsheetWorksheet = function( spreadsheet, data ){
       if (err) return cb(err);
 
       // this looks for an error that in some cases is caused by a protected worksheet
-      if (data.entry && data.entry.length) data.entry.forEach(function(cell_data) {
-        if(cell_data['gs:cell'] === undefined) return cb(new Error('[\'gs:cell\'] is undefined in response data. This may be caused by a protected worksheet.'));
-      });
+      if (data.entry && data.entry.length) {
+        for (const cell_data of data.entry) {
+          if (cell_data['gs:cell'] === undefined) {
+            return cb(new Error('Bulk update failed. [\'gs:cell\'] is undefined in response data. This may be caused by a protected worksheet.'));
+          }
+        }
+      }
 
       // update all the cells
       var cells_by_batch_id = _.keyBy(cells, 'batchId');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "google-spreadsheet",
-  "version": "2.0.5",
+  "version": "2.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -418,9 +418,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.noop": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^1.3.0",
     "google-auth-library": "^0.10.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.15",
     "request": "^2.69.0",
     "xml2js": "~0.4.0"
   },


### PR DESCRIPTION
Or rather:

Error handling for an error that *may* be triggered by a bulk update on a protected worksheet.

At least that's what causes the error in our case.

Without this suggested check the process simply crashes with the error `TypeError: Cannot read property '$' of undefined`. I hope calling `cb` with a nicer error message is seen as an improvement. It would be for us.

🙂