### PR TITLE
Add options config for gzip

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
 
   var auth_client = new GoogleAuth();
   var jwt_client;
+  var gzip = true;
 
   options = options || {};
 
@@ -86,6 +87,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
     if (!options.projection){
       projection = google_auth ? 'full' : 'values';
     }
+    gzip = options.gzip !== undefined ? options.gzip : true
   }
 
   // This method is used internally to make all requests
@@ -141,7 +143,7 @@ var GoogleSpreadsheet = function( ss_key, auth_id, options ){
           url: url,
           method: method,
           headers: headers,
-          gzip: true,
+          gzip: gzip,
           body: method == 'POST' || method == 'PUT' ? query_or_data : null
         }, function(err, response, body){
           if (err) {


### PR DESCRIPTION
I had an issue where i was using Vue JS in combination with this cool lib. It resulted in errors shown in this issue -> https://github.com/theoephraim/node-google-spreadsheet/issues/220 and below.

The error in the console looks like this

```
Error: incorrect header check
    at Zlib._handle.onerror (index.js?470b:352)
    at Zlib._error (binding.js?6b75:283)
    at Zlib._checkError (binding.js?6b75:254)
    at Zlib._after (binding.js?6b75:262)
    at eval (binding.js?6b75:126)
    at Item.run (browser.js?f28c:153)
    at drainQueue (browser.js?f28c:123)
```

## Manual resolution

I had to change gzip to false in makeFeedRequest

## Resolution

I have added a PR for the options object to include a check for gzip.