### PR TITLE
Added configurable property to GoogleSpreadsheetRow constructor

### DIFF
--- a/lib/GoogleSpreadsheetRow.js
+++ b/lib/GoogleSpreadsheetRow.js
@@ -11,6 +11,7 @@ class GoogleSpreadsheetRow {
       Object.defineProperty(this, propName, {
         get: () => this._rawData[i],
         set: (newVal) => { this._rawData[i] = newVal; },
+        configurable: true,
       });
     }
 


### PR DESCRIPTION
Added the configurable: true property to avoid error on fresh instance from the sheet.getRows() method