### PR TITLE
add v4 typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,12 @@ interface TextRotation {
 
 type RecalculationInterval = "ON_CHANGE" | "MINUTE" | "HOUR";
 
+type Dimension = "ROWS" | "COLUMNS";
+
+type DeveloperMetadataVisibility = "DOCUMENT" | "PROJECT";
+
+type DeveloperMetadataLocationType = "ROW" | "COLUMN" | "SHEET" | "SPREADSHEET";
+
 /* ---- OPTIONS / CONFIG ---- */
 
 interface PaginationOptions {
@@ -111,19 +117,36 @@ interface WorksheetGridProperties {
   columnGroupControlAfter: boolean;
 }
 
-// TODO: this one is really heavily nested: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
-interface DeveloperMetadata {}
+interface DimensionRange {
+  sheetId: number;
+  endIndex: number;
+  startIndex: number;
+  dimension: Dimension;
+}
+
+interface DeveloperMetadataLocation {
+  sheetId: number;
+  spreadsheet: boolean;
+  dimensionRange: DimensionRange;
+  locationType: DeveloperMetadataLocationType;
+}
+
+interface DeveloperMetadata {
+  metadataId: number;
+  metadataKey: string;
+  metadataValue: string;
+  location: DeveloperMetadataLocation;
+  visibility: DeveloperMetadataVisibility;
+}
 
 interface WorksheetDimensionProperties {
-  hiddenByFilter: boolean;
-  hiddenByUser: boolean;
   pixelSize: number;
+  hiddenByUser: boolean;
+  hiddenByFilter: boolean;
   /**
-   * see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
+   * @see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
    */
-  // TODO: replace when DeveloperMetadata is defined
-  // developerMetadata: [DeveloperMetadata];
-  developerMetadata: [{ [prop: string]: any }];
+  developerMetadata: [DeveloperMetadata];
 }
 
 interface WorksheetDimensionBounds {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,809 @@
+/* ---- EXPORTS ---- */
+
+// only export the GoogleSpreadsheet and GoogleSpreadsheetFormulaError
+// other classes should not be instantiated directly so they are hidden
+// but they can still be imported from index.js manually
+// they will just not appear as exports from suggestions / intellisense
+export class GoogleSpreadsheet {
+  /**
+   * @description
+   * create a new Spreadsheet doc
+   *
+   * @param sheetId document ID from the URL of the Spreadsheet
+   */
+  constructor(sheetId: string): GoogleSpreadsheet;
+}
+
+export class GoogleSpreadsheetFormulaError {
+  constructor(errorInfo: CellError): GoogleSpreadsheetFormulaError;
+}
+
+/* ---- ENUMS ---- */
+
+type WorksheetType = "GRID" | "OBJECT";
+
+type WorksheetDimension = "ROW" | "COLUMN";
+
+type HyperlinkDisplayType = "LINKED" | "PLAIN_TEXT";
+
+type CellValueType = "boolValue" | "stringValue" | "numberValue" | "errorValue";
+
+type NumberFormatType =
+  | "TEXT"
+  | "NUMBER"
+  | "PERCENT"
+  | "CURRENCY"
+  | "DATE"
+  | "TIME"
+  | "SCIENTIFIC";
+
+type CellErrorType =
+  | "ERROR"
+  | "NULL_VALUE"
+  | "DIVIDE_BY_ZERO"
+  | "VALUE"
+  | "REF"
+  | "NAME"
+  | "NUM"
+  | "N_A"
+  | "LOADING";
+
+type HorizontalAlign = "LEFT" | "CENTER" | "RIGHT";
+
+type VerticalAlign = "TOP" | "MIDDLE" | "BOTTOM";
+
+/**
+ * @see
+ * https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/cells#wrapstrategy
+ */
+type WrapStrategy = "OVERFLOW_CELL" | "LEGACY_WRAP" | "CLIP" | "WRAP";
+
+type ThemeColorType =
+  | "TEXT"
+  | "BACKGROUND"
+  | "ACCENT1"
+  | "ACCENT2"
+  | "ACCENT3"
+  | "ACCENT4"
+  | "ACCENT5"
+  | "ACCENT6"
+  | "LINK";
+
+type BorderStyle =
+  | "NONE"
+  | "DOTTED"
+  | "DASHED"
+  | "SOLID"
+  | "SOLID_MEDIUM"
+  | "SOLID_THICK"
+  | "DOUBLE";
+
+type TextDirection = "LEFT_TO_RIGHT" | "RIGHT_TO_LEFT";
+
+interface TextRotation {
+  angle: number;
+  vertical: boolean;
+}
+
+type RecalculationInterval = "ON_CHANGE" | "MINUTE" | "HOUR";
+
+/* ---- OPTIONS / CONFIG ---- */
+
+interface PaginationOptions {
+  limit: number;
+  offset: number;
+}
+
+interface WorksheetGridRange {
+  startRowIndex: number;
+  endRowIndex: number;
+  startColumnIndex: number;
+  endColumnIndex: number;
+}
+
+interface WorksheetGridProperties {
+  rowCount: number;
+  columnCount: number;
+  frozenRowCount: number;
+  frozenColumnCount: number;
+  hideGridlines: boolean;
+  rowGroupControlAfter: boolean;
+  columnGroupControlAfter: boolean;
+}
+
+// TODO: this one is really heavily nested: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
+interface DeveloperMetadata {}
+
+interface WorksheetDimensionProperties {
+  hiddenByFilter: boolean;
+  hiddenByUser: boolean;
+  pixelSize: number;
+  /**
+   * see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
+   */
+  // TODO: replace when DeveloperMetadata is defined
+  // developerMetadata: [DeveloperMetadata];
+  developerMetadata: [{ [prop: string]: any }];
+}
+
+interface WorksheetDimensionBounds {
+  startIndex: number;
+  endIndex: number;
+}
+
+interface Color {
+  red: number;
+  green: number;
+  blue: number;
+  alpha: number;
+}
+
+interface ColorStyle {
+  rgbColor: Color;
+  themeColor: ThemeColorType;
+}
+
+interface TextFormat {
+  foregroundColor: Color;
+  foregroundColorStyle: ColorStyle;
+  fontFamily: string;
+  fontSize: number;
+  bold: boolean;
+  italic: boolean;
+  strikethrough: boolean;
+  underline: boolean;
+}
+
+interface NumberFormat {
+  type: NumberFormatType;
+  /**
+   * see https://developers.google.com/sheets/api/guides/formats
+   */
+  pattern: string;
+}
+
+interface Border {
+  style: BorderStyle;
+  width: number;
+  color: Color;
+  colorStyle: ColorStyle;
+}
+
+interface Borders {
+  top: Border;
+  bottom: Border;
+  left: Border;
+  right: Border;
+}
+
+interface Padding {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+interface ThemeColorPair {
+  color: ColorStyle;
+  colorType: ThemeColorType;
+}
+
+interface SpreadsheetTheme {
+  primaryFontFamily: string;
+  themeColors: [ThemeColorPair];
+}
+
+/**
+ * see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets#iterativecalculationsettings
+ */
+interface IterativeCalculationSetting {
+  maxIterations: number;
+  convergenceThreshold: number;
+}
+
+interface CellError {
+  message: String;
+  type: CellErrorType;
+}
+
+interface CellStats {
+  nonEmpty: number;
+  loaded: number;
+  total: number;
+}
+
+interface CellFormat {
+  /**
+   * @description
+   * format describing how number values should be represented to the user
+   */
+  numberFormat: NumberFormat;
+  /**
+   * @description
+   * background color of the cell
+   */
+  backgroundColor: Color;
+  /**
+   * @description
+   * border settings of the cell
+   */
+  borders: Borders;
+  /**
+   * @description
+   * padding in the cell
+   * - spacing between inner text and cell boundaries
+   */
+  padding: Padding;
+  /**
+   * @description
+   * horizontal alignment of the cell's value
+   */
+  horizontalAlignment: HorizontalAlign;
+  /**
+   * @description
+   * vertical alignment of the cell's value
+   */
+  verticalAlignment: VerticalAlign;
+  /**
+   * @description
+   * text-wrapping strategy of the cell's value
+   */
+  wrapStrategy: WrapStrategy;
+  /**
+   * @description
+   * display direction of cell value text
+   */
+  textDirection: TextDirection;
+  /**
+   * @description
+   * format of the text in the cell
+   * - font, size etc.
+   */
+  textFormat: TextFormat;
+  /**
+   * @description
+   * how a hyperlink (if any) should be displayed
+   */
+  hyperlinkDisplayType: HyperlinkDisplayType;
+  /**
+   * @description
+   * rotation applied to text in a cell
+   */
+  textRotation: TextRotation;
+}
+
+interface ServiceAccountCredentials {
+  /**
+   * @description
+   * service account email address
+   */
+  client_email: string;
+  /**
+   * @description
+   * service account private key
+   */
+  private_key: string;
+}
+
+/* ---- GOOGLE SPREADSHEET CELL ---- */
+
+interface CellProperties extends CellFormat {
+  /**
+   * @description
+   * cell row in the worksheet
+   */
+  rowIndex: number;
+  /**
+   * @description
+   * cell column in the worksheet
+   */
+  columnIndex: number;
+  /**
+   * @description
+   * cell row number in A1 address format
+   */
+  a1Row: number;
+  /**
+   * @description
+   * cell column letter in A1 address format
+   */
+  a1Column: string;
+  /**
+   * @description
+   * cell full A1 address format
+   */
+  a1Address: string;
+
+  /**
+   * @description
+   * this is the full value in the cell
+   * - if there is a formula in the cell, this will be the value the formula resolves to
+   */
+  value: string | number | boolean;
+
+  /**
+   * @description
+   * the type of the value, using google's terminology
+   */
+  readonly valueType: CellValueType;
+  /**
+   * @description
+   * value after formatting rules are applied
+   */
+  readonly formattedValue: any;
+  /**
+   * @description
+   * formula (if any) in the cell
+   */
+  formula: string;
+  /**
+   * @description
+   * error related to an invalid cell format
+   */
+  readonly formulaError: CellError;
+  /**
+   * @description
+   * note attached to the cell
+   */
+  note: string;
+  /**
+   * @description
+   * url of the cell's link
+   * - when using =HYPERLINK() formula
+   */
+  readonly hyperlink: string;
+
+  /**
+   * @description
+   * format the user entered in the cell
+   * - note: using named format properties is preferred
+   */
+  readonly userEnteredFormat: CellFormat;
+  /**
+   * @description
+   * "effective format" used by the cell
+   * - note: using named format properties is preferred
+   * - this includes the results of applying any conditional formatting
+   * - if the cell contains a formula, the computed number format
+   * - if the effective format is the default format, effective format will not be written
+   */
+  readonly effectiveFormat: CellFormat;
+}
+
+interface GoogleSpreadsheetCell extends CellProperties {
+  /**
+   * @description
+   * reset all cell formatting to default / none
+   * - LOCAL CHANGE (must be saved to persist)
+   */
+  clearAllFormatting(): void;
+  /**
+   * @description
+   * discard all unsaved changes
+   * - includes value, notes and formatting
+   * - LOCAL CHANGE (must be saved to persist)
+   */
+  discardUnsavedChanges(): void;
+  /**
+   * @description
+   * save this individual cell
+   * - persist any local changes made to the cell
+   * - see worksheet.saveUpdatedCells() for bulk saving
+   */
+  save(): Promise<void>;
+}
+
+/* ---- GOOGLE SPREADSHEET ROW ---- */
+interface RowProperties {
+  /**
+   * @description
+   * row number in the worksheet
+   */
+  rowIndex: number;
+  /**
+   * @description
+   * full A1 formatted range of this row
+   * - includes the worksheet name, ex: "sheet1!A5:D5"
+   */
+  a1Range: string;
+}
+
+/**
+ * Property keys are determined by the header row of the sheet
+ * - each row will have a property getter/setter available for each cell corresponding to the column header
+ */
+interface GoogleSpreadsheetRow extends RowProperties {
+  /**
+   * @description
+   * save any updates made to cell values in this row
+   */
+  save(): Promise<void>;
+  /**
+   * @description
+   * delete this row
+   */
+  delete(): Promise<void>;
+}
+
+/* ---- GOOGLE SPREADSHEET WORKSHEET ---- */
+
+interface WorksheetProperties {
+  /**
+   * @description
+   * name of the worksheet tab
+   */
+  title: string;
+  /**
+   * @description
+   * tab index in the worksheet doc (based on rightToLeft property)
+   */
+  index: number;
+  /**
+   * @description
+   * additional properties of the worksheet if this sheet is a grid
+   */
+  gridProperties: WorksheetGridProperties;
+  /**
+   * @description
+   * true if the worksheet is hidden in the UI, false if it's visible
+   */
+  hidden: boolean;
+  /**
+   * @description
+   * the color of the worksheet tab
+   */
+  tabColor: Color;
+  /**
+   * @description
+   * true if the worksheet is an RTL sheet instead of an LTR sheet
+   */
+  rightToLeft: boolean;
+  /**
+   * @description
+   * number of rows in the worksheet
+   */
+  rowCount: number;
+  /**
+   * @description
+   * number of columns in the worksheet
+   */
+  columnCount: number;
+  /**
+   * @description
+   * alias for the worksheet title
+   */
+  a1SheetName: string;
+  /**
+   * @description
+   * A1 column letter of the last column in the worksheet
+   */
+  lastColumnLetter: string;
+  /**
+   * @description
+   * stats about the cells in the worksheet
+   */
+  cellStats: CellStats;
+}
+
+// workaround to not repeat interface props in implementing class
+// https://github.com/Microsoft/TypeScript/issues/340#issuecomment-184964440
+
+interface GoogleSpreadsheetWorksheet extends WorksheetProperties {
+  constructor(
+    parentSpreadsheet: GoogleSpreadsheet,
+    config: { data: any; properties: WorksheetProperties },
+  );
+
+  /**
+   * @description
+   * set during creation, not editable
+   */
+  readonly sheetId: string;
+
+  /**
+   * @description
+   * set during creation, not editable
+   */
+  readonly sheetType: WorksheetType;
+
+  /* ---- SYNCHRONOUS METHODS ---- */
+
+  /**
+   * @description
+   * retrieve a cell from the cache based on numeric row and column indices
+   */
+
+  getCell(rowIndex: number, columnIndex: number): GoogleSpreadsheetCell;
+  /**
+   * @description
+   * retrieve a cell from the cache based on A1 address
+   */
+  getCellByA1(a1Address: string): GoogleSpreadsheetCell;
+  /**
+   * @description
+   * fetch all rows in the worksheet
+   *
+   * @param options
+   */
+  getRows(options: PaginationOptions): [GoogleSpreadsheetRow];
+  /**
+   * @description
+   * eset local cache of properties and cell data
+   *
+   * @param dataOnly if true, only affects data, not properties
+   */
+  resetLocalCache(dataOnly: boolean): void;
+
+  /* ---- ASYNCHRONOUS METHODS ---- */
+
+  /**
+   * @description
+   * loads the cells in the worksheet
+   * - strings are treated as an A1 range
+   * - objects are treated as a WorksheetGridRange
+   *
+   * @param filters single or array of filters
+   */
+  loadCells(
+    filters: string | WorksheetGridRange | [string | WorksheetGridRange],
+  ): Promise<void>;
+  /**
+   * @description
+   * saves all cells in the worksheet that have unsaved changes
+   */
+  saveUpdatedCells(): Promise<void>;
+  /**
+   * @description
+   * saves all cells that have unsaved changes
+   *
+   * @param cells array of cells to save
+   */
+  saveCells(cells: [GoogleSpreadsheetCell]): Promise<void>;
+  /**
+   * @description
+   * set the header (first) row in the worksheet
+   *
+   * @param headers
+   */
+  setHeaderRow(headers: [string]): Promise<void>;
+  /**
+   * @description
+   * append a row to the end of the worksheet
+   *
+   * @param values
+   */
+  addRow(values: {
+    [header: string]: string | number | boolean;
+  }): Promise<void>;
+  /**
+   * @description
+   * set the grid properties of the worksheet
+   *
+   * @param gridProperties
+   */
+  setGridProperties(gridProperties: WorksheetGridProperties): Promise<void>;
+  /**
+   * @description
+   * update basic worksheet properties
+   *
+   * @param properties
+   */
+  updateProperties(properties: WorksheetProperties): Promise<void>;
+  /**
+   * @description
+   * update worksheet grid properties / dimensions
+   * - alias for setGridProperties
+   */
+  resize(gridProperties: WorksheetGridProperties): Promise<void>;
+  /**
+   * @description
+   * update the worksheet "dimension properties"
+   *
+   * @param columnsOrRows which dimension to update
+   *
+   * @param properties properties of the dimension to update
+   *
+   * @param bounds start and end dimension indices
+   */
+  updateDimensionProperties(
+    columnsOrRows: WorksheetDimension,
+    properties: WorksheetDimensionProperties,
+    bounds: WorksheetDimensionBounds,
+  ): Promise<void>;
+  /**
+   * @description
+   * clear all data/cells in the worksheet
+   */
+  clear(): Promise<void>;
+  /**
+   * @description
+   * delete the worksheet
+   */
+  delete(): Promise<void>;
+  /**
+   * @description
+   * copy this sheet to another document
+   *
+   * @param destinationSpreadsheetId destination spreadsheet doc ID
+   */
+  copyToSpreadSheet(destinationSpreadsheetId: string): Promise<void>;
+}
+
+/* ---- GOOGLE SPREADSHEET ---- */
+
+interface SpreadsheetProperties {
+  /**
+   * @description
+   * document ID
+   * - from the Spreadsheet document URL
+   */
+  readonly spreadsheetId;
+  /**
+   * @description
+   * document title
+   */
+  title: string;
+  /**
+   * @description
+   * document locale/language
+   * - ISO code format
+   * - ex: "en", "en_US"
+   */
+  locale: string;
+  /**
+   * @description
+   * document timezone
+   * - CLDR format
+   * - ex: "America/New_York", "GMT-07:00"
+   */
+  timeZone: string;
+  /**
+   * @description
+   * when volatile functions should be recalculated
+   */
+  autoRecalc: RecalculationInterval;
+  /**
+   * @description
+   * default format for all cells in all worksheets of the document
+   */
+  defaultFormat: CellFormat;
+  /**
+   * @description
+   * theme applied to all worksheets of the document
+   */
+  spreadsheetTheme: SpreadsheetTheme;
+  /**
+   * @description
+   * how circular dependencies are resolved with iterative calculations
+   */
+  iterativeCalculationSettings: IterativeCalculationSetting;
+
+  /**
+   * @description
+   * object of child worksheets
+   * - keyed by the worksheet sheetId
+   */
+  readonly sheetsById: { [sheetId: string]: GoogleSpreadsheetWorksheet };
+  /**
+   * @description
+   * array of child worksheets as displayed in the UI
+   * - ordered by their tab index
+   */
+  readonly sheetsByIndex: [GoogleSpreadsheetWorksheet];
+  /**
+   * @description
+   * count of child worksheets
+   * - shorthand for spreadsheetDoc.sheetsByIndex.length
+   */
+  readonly sheetCount: number;
+}
+
+interface GoogleSpreadsheet extends SpreadsheetProperties {
+  /**
+   * @description
+   * JWT-style authentication with service account credentials
+   * - used for all future requests made through the Spreadsheet document and its related objects
+   * - see https://cloud.google.com/iam/docs/service-accounts
+   *
+   * @param credentials object of Google Service Account credentials
+   * - import by requiring the JSON file Google supplies
+   *
+   * @example
+   * const credentials = require("./credentials.json");
+   * const { GoogleSpreadsheet } = require("google-spreadsheet");
+   *
+   * // create a Spreadsheet doc by the given ID
+   * const doc = new GoogleSpreadsheet(spreadsheetId);
+   *
+   * await doc.useServiceAccountAuth(credentials); // authenticate
+   * await doc.getInfo(); // load properties and worksheets
+   *
+   * // doc is ready to be used
+   */
+  useServiceAccountAuth(credentials: ServiceAccountCredentials): Promise<void>;
+  /**
+   * @description
+   * API key authentication
+   * - used for all future requests made through the Spreadsheet document and its related objects
+   * - only allows READ-ONLY access to PUBLIC Spreadsheet documents
+   *
+   * @param key API key for your Google project
+   */
+  useApiKey(key: string): void;
+
+  /**
+   * @description
+   * load basic Spreadsheet document properties and child worksheets
+   */
+  loadInfo(): Promise<void>;
+
+  /**
+   * @description
+   * update basic Spreadsheet document properties
+   *
+   * @param properties basic Spreadsheet document properties to update
+   */
+  updateProperties(properties: SpreadsheetProperties): Promise<void>;
+  /**
+   * @description
+   * clear local cache of properties and child worksheets
+   * - note: you must call loadInfo() again to re-load the cache
+   */
+  resetLocalCache(): void;
+
+  /**
+   * @description
+   * add a new worksheet to the Spreadsheet document
+   * - also available as addWorksheet()
+   *
+   * @param worksheetProperties all worksheet properties to set
+   */
+  addSheet(
+    worksheetProperties?: WorksheetProperties,
+  ): Promise<GoogleSpreadsheetWorksheet>;
+  /**
+   * @description
+   * add a new worksheet to the Spreadsheet document
+   * - alias for addSheet()
+   *
+   * @param worksheetProperties all worksheet properties to set
+   */
+  addWorksheet(
+    worksheetProperties?: WorksheetProperties,
+  ): Promise<GoogleSpreadsheetWorksheet>;
+  /**
+   * @description
+   * delete a worksheet from the Spreadsheet document
+   * - preferred to use delete() method on the worksheet object itself
+   *
+   * @param sheetId ID of the worksheet to delete
+   */
+  deleteSheet(sheetId: string): Promise<void>;
+
+  /**
+   * @description
+   * add a new named range to the Spreadsheet Document
+   *
+   * @param name name of the range
+   * - used in formulas to refer to it
+   *
+   * @param range A1 formatted range or GridRange object
+   *
+   * @param rangeId unique ID for the range
+   * - autogenerated if empty
+   */
+  addNamedRange(
+    name: string,
+    range: string | WorksheetGridRange,
+    rangeId?: string,
+  );
+  /**
+   * @description
+   * delete a named range from the Spreadsheet document
+   *
+   * @param rangeId unique ID of the range to delete
+   */
+  deleteNamedRange(rangeId: string);
+}
+
+interface GoogleSpreadsheetFormulaError extends CellError {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ interface WorksheetDimensionProperties {
   /**
    * @see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
    */
-  developerMetadata: [DeveloperMetadata];
+  developerMetadata: DeveloperMetadata[];
 }
 
 interface WorksheetDimensionBounds {
@@ -255,7 +255,7 @@ interface ThemeColorPair {
 
 interface SpreadsheetTheme {
   primaryFontFamily: string;
-  themeColors: [ThemeColorPair];
+  themeColors: ThemeColorPair[];
 }
 
 /**
@@ -593,7 +593,7 @@ interface GoogleSpreadsheetWorksheet extends WorksheetBasicProperties {
    *
    * @param options
    */
-  getRows(options: PaginationOptions): [GoogleSpreadsheetRow];
+  getRows(options?: PaginationOptions): Promise<GoogleSpreadsheetRow[]>;
   /**
    * @description
    * eset local cache of properties and cell data
@@ -613,7 +613,7 @@ interface GoogleSpreadsheetWorksheet extends WorksheetBasicProperties {
    * @param filters single or array of filters
    */
   loadCells(
-    filters: string | WorksheetGridRange | [string | WorksheetGridRange],
+    filters: string | WorksheetGridRange | string[] | WorksheetGridRange[],
   ): Promise<void>;
   /**
    * @description
@@ -626,14 +626,14 @@ interface GoogleSpreadsheetWorksheet extends WorksheetBasicProperties {
    *
    * @param cells array of cells to save
    */
-  saveCells(cells: [GoogleSpreadsheetCell]): Promise<void>;
+  saveCells(cells: GoogleSpreadsheetCell[]): Promise<void>;
   /**
    * @description
    * set the header (first) row in the worksheet
    *
    * @param headers
    */
-  setHeaderRow(headers: [string]): Promise<void>;
+  setHeaderRow(headers: string[]): Promise<void>;
   /**
    * @description
    * append a row to the end of the worksheet
@@ -769,7 +769,7 @@ interface GoogleSpreadsheet extends SpreadsheetBasicProperties {
    * array of child worksheets as displayed in the UI
    * - ordered by their tab index
    */
-  readonly sheetsByIndex: [GoogleSpreadsheetWorksheet];
+  readonly sheetsByIndex: GoogleSpreadsheetWorksheet[];
   /**
    * @description
    * count of child worksheets

--- a/index.d.ts
+++ b/index.d.ts
@@ -505,6 +505,14 @@ interface WorksheetBasicProperties {
 
   /**
    * @description
+   * first row values
+   * - used in row-based interactions
+   * - defines the dynamic properties of the Worksheet's GoogleSpreadsheetRows
+   */
+  headerValues: string[];
+
+  /**
+   * @description
    * name of the worksheet tab
    */
   title: string;
@@ -634,6 +642,12 @@ interface GoogleSpreadsheetWorksheet extends WorksheetBasicProperties {
    * @param headers
    */
   setHeaderRow(headers: string[]): Promise<void>;
+  /**
+   * @description
+   * loads the header row (first row) of the sheet
+   * - usually do not need to call this directly
+   */
+  loadHeaderRow(): Promise<void>;
   /**
    * @description
    * append a row to the end of the worksheet

--- a/index.d.ts
+++ b/index.d.ts
@@ -638,11 +638,17 @@ interface GoogleSpreadsheetWorksheet extends WorksheetBasicProperties {
    * @description
    * append a row to the end of the worksheet
    *
-   * @param values
+   * @param values row values as either:
+   * - an object of header and value pairs (relative to the worksheet header columns)
+   * - an array of values in column order
    */
-  addRow(values: {
-    [header: string]: string | number | boolean;
-  }): Promise<void>;
+  addRow(
+    values:
+      | {
+          [header: string]: string | number | boolean;
+        }
+      | (string | number | boolean)[],
+  ): Promise<void>;
   /**
    * @description
    * set the grid properties of the worksheet

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,11 +11,11 @@ export class GoogleSpreadsheet {
    *
    * @param sheetId document ID from the URL of the Spreadsheet
    */
-  constructor(sheetId: string): GoogleSpreadsheet;
+  constructor(sheetId: string);
 }
 
 export class GoogleSpreadsheetFormulaError {
-  constructor(errorInfo: CellError): GoogleSpreadsheetFormulaError;
+  constructor(errorInfo: CellError);
 }
 
 /* ---- ENUMS ---- */
@@ -489,11 +489,6 @@ interface WorksheetProperties {
 // https://github.com/Microsoft/TypeScript/issues/340#issuecomment-184964440
 
 interface GoogleSpreadsheetWorksheet extends WorksheetProperties {
-  constructor(
-    parentSpreadsheet: GoogleSpreadsheet,
-    config: { data: any; properties: WorksheetProperties },
-  );
-
   /**
    * @description
    * set during creation, not editable

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "git://github.com/theoephraim/node-google-spreadsheet.git"
   },
   "main": "index.js",
+  "typings": "index.d.ts",
   "engines": {
     "node": ">=0.8.0"
   },


### PR DESCRIPTION
- exported classes: GoogleSpreadsheet, GoogleSpreadsheetFormulaError
- added "typings" field to package.json
- used google-spreadsheet docs for reference of public props/methods and documentation (will not autocomplete internal `_` props/methods)
  - anything listed in the docs has been typed (enums, option/config objects, classes)
  - used google API docs as a supplement for missing documentation

~~TODO:~~
- ~~only incomplete type is DeveloperMetadata (heavily nested) added a link to the google API docs for reference instead~~