### PR TITLE
Fix/spreadsheet/add sheet

### DIFF
--- a/lib/GoogleSpreadsheet.js
+++ b/lib/GoogleSpreadsheet.js
@@ -238,16 +238,18 @@ class GoogleSpreadsheet {
     // Request type = `addSheet`
     // https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request#AddSheetRequest
 
+    const { headers, headerValues, ...onlyUpdateProps } = properties;
     const response = await this._makeSingleUpdateRequest('addSheet', {
-      properties: _.omit(properties, 'headers'),
+      properties: onlyUpdateProps,
     });
     // _makeSingleUpdateRequest already adds the sheet
     const newSheetId = response.properties.sheetId;
     const newSheet = this.sheetsById[newSheetId];
 
     // allow it to work with `.headers` but `.headerValues` is the real prop
-    if (properties.headers) { await newSheet.setHeaderRow(properties.headers); }
-    if (properties.headerValues) { await newSheet.setHeaderRow(properties.headerValues); }
+    if (headers || headerValues) {
+      await newSheet.setHeaderRow(headers || headerValues);
+    }
 
     return newSheet;
   }

--- a/test/manage.test.js
+++ b/test/manage.test.js
@@ -33,7 +33,9 @@ describe('Managing doc info and sheets', () => {
     });
 
     it('throws an error if updating title directly', async () => {
-      expect(() => { doc.title = 'new title'; }).toThrow();
+      expect(() => {
+        doc.title = 'new title';
+      }).toThrow();
     });
 
     it('can update the title using updateProperties', async () => {
@@ -62,18 +64,37 @@ describe('Managing doc info and sheets', () => {
       if (sheet) await sheet.delete();
     });
 
-    it('can add a sheet', async () => {
-      const numSheets = doc.sheetCount;
-      sheet = await doc.addWorksheet({
+    // to de-duplicate the test cases for header and headerValues
+    const addSheet = (variableProperties) => {
+      const baseProperties = {
         title: newSheetTitle,
         gridProperties: {
           rowCount: 7,
           columnCount: 11,
         },
-        headers: ['col1', 'col2', 'col3', 'col4', 'col5'],
-      });
-      expect(doc.sheetCount).toBe(numSheets + 1);
+      };
 
+      const properties = { ...baseProperties, ...variableProperties };
+      return doc.addWorksheet(properties);
+    };
+
+    it('can add a sheet using properties.headers', async () => {
+      const numSheets = doc.sheetCount;
+      sheet = await addSheet({ headers: ['col1', 'col2', 'col3', 'col4', 'col5'] });
+
+      expect(doc.sheetCount).toBe(numSheets + 1);
+      expect(sheet.title).toBe(newSheetTitle);
+
+      // tests are tightly coupled
+      // delete this sheet and allow the next to survive for remaining tests
+      await sheet.delete();
+    });
+
+    it('can add a sheet using properties.headerValues', async () => {
+      const numSheets = doc.sheetCount;
+      sheet = await addSheet({ headerValues: ['col1', 'col2', 'col3', 'col4', 'col5'] });
+
+      expect(doc.sheetCount).toBe(numSheets + 1);
       expect(sheet.title).toBe(newSheetTitle);
     });
 
@@ -110,7 +131,9 @@ describe('Managing doc info and sheets', () => {
     });
 
     it('throws an error if updating title directly', async () => {
-      expect(() => { sheet.title = 'new title'; }).toThrow();
+      expect(() => {
+        sheet.title = 'new title';
+      }).toThrow();
     });
 
     it('can update the title using updateProperties', async () => {
@@ -126,7 +149,9 @@ describe('Managing doc info and sheets', () => {
 
     it('can resize a sheet', async () => {
       // cannot update directly
-      expect(() => { sheet.rowCount = 77; }).toThrow();
+      expect(() => {
+        sheet.rowCount = 77;
+      }).toThrow();
       await sheet.resize({ rowCount: 77, columnCount: 44 });
       expect(sheet.rowCount).toBe(77);
       sheet.resetLocalCache();


### PR DESCRIPTION
solves `addSheet` bug with `properties.headerValues` from #300 
- added test case (minimal restructuring to not duplicate logic)
- fixed implementation