### PR TITLE
feat: add support for auth via oauth2 access token

### DIFF
--- a/lib/GoogleSpreadsheet.js
+++ b/lib/GoogleSpreadsheet.js
@@ -19,6 +19,7 @@ const GOOGLE_AUTH_SCOPES = [
 const AUTH_MODES = {
   JWT: 'JWT',
   API_KEY: 'API_KEY',
+  ACCESS_TOKEN: 'ACCESS_TOKEN',
 };
 
 class GoogleSpreadsheet {
@@ -73,6 +74,12 @@ class GoogleSpreadsheet {
     */
   }
 
+  async useAccessToken(token) {
+    // TODO: add full oauth2 support including refreshing the access token
+    this.authMode = AUTH_MODES.ACCESS_TOKEN;
+    this.accessToken = token;
+  }
+
   // TODO: provide mechanism to share single JWT auth between docs?
 
   // INTERNAL UTILITY FUNCTIONS ////////////////////////////////////////////////////////////////////
@@ -87,6 +94,9 @@ class GoogleSpreadsheet {
       if (!this.apiKey) throw new Error('Please set API key');
       config.params = config.params || {};
       config.params.key = this.apiKey;
+    } else if (this.authMode === AUTH_MODES.ACCESS_TOKEN) {
+      if (!this.accessToken) throw new Error('Invalid access token');
+      config.headers.Authorization = `Bearer ${this.accessToken}`;
     } else {
       throw new Error('You must initialize some kind of auth before making any requests');
     }


### PR DESCRIPTION
Super simple change.

Tested locally but not sure the best way to add automated tests since the access token is sensitive.

I figure this is a solid first pass at oauth2 support #277 and we can always add the more involved logic for refreshing an access token later. Also affects #168 and probably some others.

For my use case, I have to use an offline, server-generated access token so the whole refresh logic and use of `google-auth-library` would actually a hindrance on the client-side. As long as this lib supports setting the access token directly, this will work on my end.

Thanks for the great lib! 🙏 