### PR TITLE
doc: scroll to page top on navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,7 @@
   <div id="app"></div>
   <script>
     window.$docsify = {
+      auto2top: true,
       name: 'google-spreadsheet',
       repo: 'https://github.com/theoephraim/node-google-spreadsheet',
       loadSidebar: true,


### PR DESCRIPTION
**Problem**: currently when navigating from page to page in docs, scroll position is maintained.
E.g. go to https://theoephraim.github.io/node-google-spreadsheet/#/classes/google-spreadsheet, scroll to `addSheet` and click on `GoogleSpreadsheetWorksheet` reference. You will get to the Worksheet page, but scroll will stuck somewhere in the middle of the page.

**Solution**: enable `auto2top` setting in docsify config. Looks like Docsify will have it `on` by default and config option will be removed altogether in v5: https://github.com/docsifyjs/docsify/pull/744#issuecomment-485661727