### PR TITLE
Added headerIndex to GoogleSpreadsheetWorksheet.js

### DIFF
--- a/lib/GoogleSpreadsheetWorksheet.js
+++ b/lib/GoogleSpreadsheetWorksheet.js
@@ -27,7 +27,7 @@ class GoogleSpreadsheetWorksheet {
 
     this._rowMetadata = []; // 1d sparse array
     this._columnMetadata = [];
-
+    this.headerRowIndex = 0;
     if (data) this._fillCellData(data);
 
     return this;
@@ -287,7 +287,9 @@ class GoogleSpreadsheetWorksheet {
   // ROW BASED FUNCTIONS ///////////////////////////////////////////////////////////////////////////
 
   async loadHeaderRow() {
-    const rows = await this.getCellsInRange(`A1:${this.lastColumnLetter}1`);
+    const a1Index = this.headerRowIndex + 1 || 1;
+    const range = `A${a1Index}:${this.lastColumnLetter}${a1Index}`;
+    const rows = await this.getCellsInRange(range);
     if (!rows) {
       throw new Error('No values in the header row - fill the first row with header values before trying to interact with rows');
     }
@@ -420,12 +422,14 @@ class GoogleSpreadsheetWorksheet {
 
     options.offset = options.offset || 0;
     options.limit = options.limit || this.rowCount - 1;
-
+    options.headerRowIndex = options.headerRowIndex || 0;
+    options.skipEmpty = options.skipEmty || false;
+    this.headerRowIndex = options.headerRowIndex;
     if (!this.headerValues) await this.loadHeaderRow();
 
     const firstRow = 2 + options.offset; // skip first row AND not zero indexed
     const lastRow = firstRow + options.limit - 1; // inclusive so we subtract 1
-    const lastColumn = columnToLetter(this.headerValues.length);
+    const lastColumn = !options.skipEmpty? columnToLetter(this.headerValues.length): columnToLetter(lastColumn);
     const rawRows = await this.getCellsInRange(
       `A${firstRow}:${lastColumn}${lastRow}`
     );


### PR DESCRIPTION
```JS
 const rows = await sheet.getRows({
    headerRowIndex: 4, // index where located headerValues
    skipEmpty: false,
  })
```
#462  fix