### PR TITLE
Adds new auth mode to use the default google auth client

### DIFF
--- a/lib/GoogleSpreadsheet.js
+++ b/lib/GoogleSpreadsheet.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { JWT } = require('google-auth-library');
+const { JWT, GoogleAuth } = require('google-auth-library');
 const Axios = require('axios');
 
 const GoogleSpreadsheetWorksheet = require('./GoogleSpreadsheetWorksheet');
@@ -20,7 +20,7 @@ const AUTH_MODES = {
   JWT: 'JWT',
   API_KEY: 'API_KEY',
   RAW_ACCESS_TOKEN: 'RAW_ACCESS_TOKEN',
-  OAUTH: 'OAUTH',
+  AUTH_CLIENT: 'AUTH_CLIENT',
 };
 
 class GoogleSpreadsheet {
@@ -78,6 +78,17 @@ class GoogleSpreadsheet {
   }
 
   // AUTH RELATED FUNCTIONS ////////////////////////////////////////////////////////////////////////
+  async useAuthClient(authClient) {
+    this.authMode = AUTH_MODES.AUTH_CLIENT;
+    this.authClient = authClient;
+  }
+
+  async useDefaultAuthClient() {
+    await this.useAuthClient(
+      await new GoogleAuth({ scopes: GOOGLE_AUTH_SCOPES }).getClient()
+    );
+  }
+
   async useApiKey(key) {
     this.authMode = AUTH_MODES.API_KEY;
     this.apiKey = key;
@@ -90,8 +101,7 @@ class GoogleSpreadsheet {
   }
 
   async useOAuth2Client(oAuth2Client) {
-    this.authMode = AUTH_MODES.OAUTH;
-    this.oAuth2Client = oAuth2Client;
+    await this.useAuthClient(oAuth2Client);
   }
 
   // creds should be an object obtained by loading the json file google gives you
@@ -127,7 +137,9 @@ class GoogleSpreadsheet {
   // INTERNAL UTILITY FUNCTIONS ////////////////////////////////////////////////////////////////////
   async _setAxiosRequestAuth(config) {
     // TODO: check auth mode, if valid, renew if expired, etc
-    if (this.authMode === AUTH_MODES.JWT) {
+    if (this.authMode === AUTH_MODES.AUTH_CLIENT) {
+      Object.assign(config.headers, await this.authClient.getRequestHeaders());
+    } else if (this.authMode === AUTH_MODES.JWT) {
       if (!this.jwtClient) throw new Error('JWT auth is not set up properly');
       // this seems to do the right thing and only renew the token if expired
       await this.jwtClient.authorize();
@@ -139,9 +151,6 @@ class GoogleSpreadsheet {
       if (!this.apiKey) throw new Error('Please set API key');
       config.params = config.params || {};
       config.params.key = this.apiKey;
-    } else if (this.authMode === AUTH_MODES.OAUTH) {
-      const credentials = await this.oAuth2Client.getAccessToken();
-      config.headers.Authorization = `Bearer ${credentials.token}`;
     } else {
       throw new Error('You must initialize some kind of auth before making any requests');
     }


### PR DESCRIPTION
Works out of the box when deployed on GCP, or using
GOOGLE_APPLICATION_CREDENTIALS env var for local dev.