### PR TITLE
Error when trying to save an empty row.

### DIFF
--- a/lib/GoogleSpreadsheetRow.js
+++ b/lib/GoogleSpreadsheetRow.js
@@ -48,7 +48,10 @@ class GoogleSpreadsheetRow {
         values: [this._rawData],
       },
     });
-    this._rawData = response.data.updatedData.values[0];
+    this._rawData = response.data.updatedData?.values[0] || this._rawData.map(emptyCellValue => '');
+    // sending an array of empty strings such as ["", ""] (Clearing the row)
+    // will result in a response with no `.value` in it, thus causing an error `cannot read property '0' of undefined.
+    // This fix will return an array of empty strings, the array of the length is the array of the original request's rawData
   }
 
   // delete this row


### PR DESCRIPTION
Error when trying to save an empty row. Note, saving an empty row is not the same as deleting one.

sending an array of empty strings such as ["", ""] (Clearing the row)
 will result in a response with no `.value` in it, thus causing an error `cannot read property '0' of undefined.
 This fix will return an array of empty strings, the array of the length is the array of the original request's rawData