### PR TITLE
feat(worksheet): allow change valueInputOption for header row

### DIFF
--- a/docs/classes/google-spreadsheet-worksheet.md
+++ b/docs/classes/google-spreadsheet-worksheet.md
@@ -76,13 +76,15 @@ Param|Type|Required|Description
 
 - ✨ **Side effects** - `sheet.headerValues` is populated
 
-#### `setHeaderRow(headerValues, headerRowIndex)` (async) :id=fn-setHeaderRow
+#### `setHeaderRow(headerValues, headerRowIndex, options)` (async) :id=fn-setHeaderRow
 > Set the header row (usually first) of the sheet
 
 Param|Type|Required|Description
 ---|---|---|---
 `headerValues`|[String]|✅|Array of strings to set as cell values in first row
 `headerRowIndex`|Number<br>_int >= 1_|-|Optionally set custom header row index, if headers are not in first row<br>NOTE - not zero-indexed, 1 = first
+`options`|Object|-|Optionally set custom params
+`options.valueInputOption`|String|-| valueInputOptions, default USER_ENTERED <br>_see [ValueInputOption](https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption)
 
 - ✨ **Side effects** - header row of the sheet is filled, `sheet.headerValues` is populated
 

--- a/lib/GoogleSpreadsheetWorksheet.js
+++ b/lib/GoogleSpreadsheetWorksheet.js
@@ -300,7 +300,7 @@ class GoogleSpreadsheetWorksheet {
     checkForDuplicateHeaders(this.headerValues);
   }
 
-  async setHeaderRow(headerValues, headerRowIndex) {
+  async setHeaderRow(headerValues, headerRowIndex, options) {
     if (!headerValues) return;
     if (headerValues.length > this.columnCount) {
       throw new Error(`Sheet is not large enough to fit ${headerValues.length} columns. Resize the sheet first.`);
@@ -318,7 +318,7 @@ class GoogleSpreadsheetWorksheet {
       method: 'put',
       url: `/values/${this.encodedA1SheetName}!${this._headerRowIndex}:${this._headerRowIndex}`,
       params: {
-        valueInputOption: 'USER_ENTERED', // other option is RAW
+        valueInputOption: _.get(options, 'valueInputOption', 'USER_ENTERED'), // other option is RAW
         includeValuesInResponse: true,
       },
       data: {


### PR DESCRIPTION
Hi,

I suggest this change cause I've a bug on one of my devs.

In France, we mostly use dates with this format : dd/mm/yyyy and the leading 0 is important on day, month and year.

But with USER_ENTERED, at least on french version of google spreadsheet, it removes each time the leading 0 on the month. Don't understand why.

So a solution is to allow developper choose its `valueInputOption`.

My PR don't break anything, just add an option which still use by default USER_ENTERED