### PR TITLE
removing limits in axios for large requests

### DIFF
--- a/lib/GoogleSpreadsheet.js
+++ b/lib/GoogleSpreadsheet.js
@@ -33,6 +33,10 @@ class GoogleSpreadsheet {
 
     // create an axios instance with sheet root URL and interceptors to handle auth
     this.axios = Axios.create({
+      // removing limits in axios for large requests
+      // https://stackoverflow.com/questions/56868023/error-request-body-larger-than-maxbodylength-limit-when-sending-base64-post-req
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
       baseURL: `https://sheets.googleapis.com/v4/spreadsheets/${sheetId || ''}`,
       // send arrays in params with duplicate keys - ie `?thing=1&thing=2` vs `?thing[]=1...`
       // solution taken from https://github.com/axios/axios/issues/604


### PR DESCRIPTION
https://stackoverflow.com/questions/56868023/error-request-body-larger-than-maxbodylength-limit-when-sending-base64-post-req