### PR TITLE
Extended GoogleSpreadsheetRow.js to permit toJson() export

### DIFF
--- a/lib/GoogleSpreadsheetRow.js
+++ b/lib/GoogleSpreadsheetRow.js
@@ -51,6 +51,16 @@ class GoogleSpreadsheetRow {
     this._rawData = response.data.updatedData.values[0];
   }
 
+  toJson() {
+    const resObj = {};
+    for (let i = 0; i < this._sheet.headerValues.length; i++) {
+      const propName = this._sheet.headerValues[i];
+      if (!propName) continue; // skip empty header
+      resObj[propName] = this._rawData[i];
+    }
+    return resObj;
+  }
+  
   // delete this row
   async delete() {
     if (this._deleted) throw new Error('This row has been deleted - call getRows again before making updates.');


### PR DESCRIPTION
Export a GoogleSpreadsheetRow to json .