### PR TITLE
fix: ability to save a formula as a string using the cell-based interface

### DIFF
--- a/src/lib/GoogleSpreadsheetCell.ts
+++ b/src/lib/GoogleSpreadsheetCell.ts
@@ -128,10 +128,8 @@ export class GoogleSpreadsheetCell {
     return this.value as string;
   }
   set stringValue(val: string | undefined) {
-    if (val?.startsWith('=')) {
-      throw new Error('Use cell.formula to set formula values');
-    }
-    this.value = val;
+    this._draftData.valueType = 'stringValue';
+    this._draftData.value = val || '';
   }
 
   /**


### PR DESCRIPTION
- add ability to save a formula or any string which starts with `=` as a string using the cell-based interface