### PR TITLE
fix: match color style type to that in google api

### DIFF
--- a/src/lib/types/sheets-types.ts
+++ b/src/lib/types/sheets-types.ts
@@ -415,7 +415,7 @@ export type DataFilterWithoutWorksheetId = A1Range | GridRangeWithoutWorksheetId
 
 
 /** @see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#colorstyle */
-export type ColorStyle = { Color: Color } | { themeColor: ThemeColorType };
+export type ColorStyle = { rgbColor: Color } | { themeColor: ThemeColorType };
 /** @see https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#Color */
 export type Color = {
   red: number,


### PR DESCRIPTION
- changed incorrect `ColorStyle` type field `Color` to `rgbColor`.

![image](https://github.com/theoephraim/node-google-spreadsheet/assets/50549441/d1e37bd5-5473-4e15-a208-dd658d3ab098)
