### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/update-deps.md
+++ b/.bumpy/update-deps.md
@@ -1,7 +1,0 @@
----
-google-spreadsheet: minor
----
-
-upgrade ky from v1 to v2
-
-If you use `doc.sheetsApi` or `doc.driveApi` directly, note that ky v2 changed its hook signatures (hooks now receive state objects instead of direct Request/Error params) and renamed `prefixUrl` to `prefix`. See the [ky v2 migration guide](https://github.com/sindresorhus/ky/releases/tag/v2.0.0) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `google-spreadsheet` changelog
 
+
+## 5.3.0
+<sub>2026-06-03</sub>
+
+- [#754](https://github.com/theoephraim/node-google-spreadsheet/pull/754)  *(minor)* - upgrade ky from v1 to v2
+  If you use `doc.sheetsApi` or `doc.driveApi` directly, note that ky v2 changed its hook signatures (hooks now receive state objects instead of direct Request/Error params) and renamed `prefixUrl` to `prefix`. See the [ky v2 migration guide](https://github.com/sindresorhus/ky/releases/tag/v2.0.0) for details.
+
 ## 5.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-spreadsheet",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Google Sheets API -- simple interface to read/write data and manage sheets",
   "keywords": [
     "google spreadsheets",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `google-spreadsheet` 5.2.0 → **5.3.0** <sub>[CHANGELOG.md](https://github.com/theoephraim/node-google-spreadsheet/pull/755/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- upgrade ky from v1 to v2 ([bump file](https://github.com/theoephraim/node-google-spreadsheet/pull/755/changes#diff-5e2a0b773b9433e2568277d87eb83c404cf900d69d872c7a5dcdba83c30cd030))
  If you use `doc.sheetsApi` or `doc.driveApi` directly, note that ky v2 changed its hook signatures (hooks now receive state objects instead of direct Request/Error params) and renamed `prefixUrl` to `prefix`. See the [ky v2 migration guide](https://github.com/sindresorhus/ky/releases/tag/v2.0.0) for details.
